### PR TITLE
[0.2.0] Query Elective Subject Details

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,2 @@
 [workspace]
-members = [
-    "mysk-data-api",
-    "mysk-lib", "mysk-lib-derives", "mysk-lib-macros",
-]
+members = ["mysk-data-api", "mysk-lib", "mysk-lib-derives", "mysk-lib-macros"]

--- a/mysk-data-api/src/routes/v1/subjects/electives/mod.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/mod.rs
@@ -1,7 +1,9 @@
 use actix_web::web;
 
+pub mod query_elective_details;
 pub mod query_electives;
 
 pub fn config(cfg: &mut web::ServiceConfig) {
     cfg.service(query_electives::query_elective_subject);
+    cfg.service(query_elective_details::query_elective_details);
 }

--- a/mysk-data-api/src/routes/v1/subjects/electives/query_elective_details.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/query_elective_details.rs
@@ -1,0 +1,38 @@
+use actix_web::{get, web, HttpResponse, Responder};
+
+use mysk_lib::{
+    models::{
+        common::{
+            requests::{QueryablePlaceholder, RequestType, SortablePlaceholder},
+            response::{MetadataType, ResponseType},
+            traits::TopLevelGetById,
+        },
+        elective_subject::ElectiveSubject,
+    },
+    prelude::*,
+};
+use uuid::Uuid;
+
+use crate::middlewares::api_key::HaveApiKey;
+use crate::AppState;
+
+#[get("/{id}")]
+pub async fn query_elective_details(
+    data: web::Data<AppState>,
+    path: web::Path<(Uuid,)>,
+    request_query: RequestType<ElectiveSubject, QueryablePlaceholder, SortablePlaceholder>,
+    _: HaveApiKey,
+) -> Result<impl Responder> {
+    let pool = &data.db;
+
+    let id = path.into_inner().0;
+    let fetch_level = request_query.fetch_level.as_ref();
+    let descendant_fetch_level = request_query.descendant_fetch_level.as_ref();
+
+    let elective_subject =
+        ElectiveSubject::get_by_id(pool, id, fetch_level, descendant_fetch_level).await?;
+
+    let response = ResponseType::new(elective_subject, Some(MetadataType::default()));
+
+    Ok(HttpResponse::Ok().json(response))
+}

--- a/mysk-lib-macros/src/traits/db.rs
+++ b/mysk-lib-macros/src/traits/db.rs
@@ -1,3 +1,5 @@
+use std::future::Future;
+
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -9,11 +11,14 @@ pub trait BaseQuery {
 
 // only for struct with id: Uuid and implements BaseQuery
 pub trait GetById: BaseQuery {
-    async fn get_by_id(pool: &PgPool, id: Uuid) -> Result<Self, sqlx::Error>
+    fn get_by_id(pool: &PgPool, id: Uuid) -> impl Future<Output = Result<Self, sqlx::Error>>
     where
         Self: Sized;
 
-    async fn get_by_ids(pool: &PgPool, ids: Vec<Uuid>) -> Result<Vec<Self>, sqlx::Error>
+    fn get_by_ids(
+        pool: &PgPool,
+        ids: Vec<Uuid>,
+    ) -> impl Future<Output = Result<Vec<Self>, sqlx::Error>>
     where
         Self: Sized;
 }

--- a/mysk-lib/src/models/common/requests.rs
+++ b/mysk-lib/src/models/common/requests.rs
@@ -118,7 +118,9 @@ where
 
     fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
         let query_string = req.query_string();
-        let request_query = serde_qs::from_str::<RequestType<T, Queryable, Sortable>>(query_string);
+        let qs_parser = serde_qs::Config::new(5, false);
+        let request_query =
+            qs_parser.deserialize_str::<RequestType<T, Queryable, Sortable>>(query_string);
 
         match request_query {
             Ok(query) => futures::future::ready(Ok(query)),


### PR DESCRIPTION
![image](https://github.com/suankularb-wittayalai-school/mysk-api/assets/72642849/7e776a0d-687a-44a1-8cf9-3643da1da22b)

**Features**
- Query elective subject details implemented (`GET /subjects/electives/{id}`).

**Fixes**
- Encoded square brackets in query strings will now be accepted and parsed as keys by `serde_qs`.
- Fixes BACK-43

P.S @smartwhatt: Do you prefer that we use merged or unmerged import lines?