### PR TITLE
[0.2.0] Session code based elective subject

### DIFF
--- a/mysk-data-api/src/main.rs
+++ b/mysk-data-api/src/main.rs
@@ -22,8 +22,8 @@ async fn main() -> io::Result<()> {
     dotenv().ok();
     env_logger::init();
     let config = Config::init();
-    let host = config.host.clone();
-    let port = config.port.clone();
+    let host = config.host;
+    let port = config.port;
 
     let pool = match PgPoolOptions::new()
         .max_connections(15)

--- a/mysk-data-api/src/routes/v1/subjects/electives/enroll_electives.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/enroll_electives.rs
@@ -14,7 +14,8 @@ use mysk_lib::{
     },
     helpers::date::{get_current_academic_year, get_current_semester},
     models::{
-        classroom::Classroom, elective_subject::ElectiveSubject, student::Student,
+        elective_subject::{db::DbElectiveSubject, ElectiveSubject},
+        student::Student,
         traits::TopLevelGetById as _,
     },
     prelude::*,
@@ -65,35 +66,21 @@ pub async fn enroll_elective_subject(
         _ => unreachable!("ElectiveSubject::get_by_id should always return a Detailed variant"),
     };
 
+    let _student = Student::get_by_id(pool, student_id, Some(&FetchLevel::IdOnly), None)
+        .await
+        .map_err(|e| {
+            Error::InvalidPermission(
+                e.to_string(),
+                format!("/subjects/electives/{session_code}/enroll"),
+            )
+        })?;
+
     // Checks if the student is in a class available for the elective
-    let student = Student::get_by_id(pool, student_id, Some(&FetchLevel::Default), None).await?;
-    match student {
-        Student::Default(student, _) => match student.classroom {
-            None => {
-                return Err(Error::InvalidPermission(
-                    "Student is not in a class".to_string(),
-                    format!("/subjects/electives/{session_code}/enroll"),
-                ));
-            }
-            Some(classroom) => {
-                if !elective
-                    .applicable_classrooms
-                    .iter()
-                    .any(|c| match (c, &classroom) {
-                        (Classroom::IdOnly(c, _), Classroom::IdOnly(classroom, _)) => {
-                            c.id == classroom.id
-                        }
-                        _ => false,
-                    })
-                {
-                    return Err(Error::InvalidPermission(
-                        "Student is not in a class available for the elective".to_string(),
-                        format!("/subjects/electives/{session_code}/enroll"),
-                    ));
-                }
-            }
-        },
-        _ => unreachable!("Student::get_by_id should always return a Default variant"),
+    if !DbElectiveSubject::is_student_eligible(pool, session_code, student_id).await? {
+        return Err(Error::InvalidPermission(
+            "Student is not eligible to enroll in this elective".to_string(),
+            format!("/subjects/electives/{session_code}/enroll"),
+        ));
     }
 
     // Checks if the student has already enrolled in the elective before

--- a/mysk-data-api/src/routes/v1/subjects/electives/query_elective_details.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/query_elective_details.rs
@@ -9,15 +9,14 @@ use mysk_lib::{
         requests::{QueryablePlaceholder, RequestType, SortablePlaceholder},
         response::ResponseType,
     },
-    models::{elective_subject::ElectiveSubject, traits::TopLevelGetById as _},
+    models::elective_subject::ElectiveSubject,
     prelude::*,
 };
-use uuid::Uuid;
 
-#[get("/{id}")]
+#[get("/{session_code}")]
 pub async fn query_elective_details(
     data: Data<AppState>,
-    path: Path<Uuid>,
+    path: Path<i64>,
     request_query: RequestType<ElectiveSubject, QueryablePlaceholder, SortablePlaceholder>,
     _api_key: ApiKeyHeader,
 ) -> Result<impl Responder> {
@@ -27,7 +26,7 @@ pub async fn query_elective_details(
     let descendant_fetch_level = request_query.descendant_fetch_level.as_ref();
 
     let elective_subject =
-        ElectiveSubject::get_by_id(pool, id, fetch_level, descendant_fetch_level).await?;
+        ElectiveSubject::get_by_session_code(pool, id, fetch_level, descendant_fetch_level).await?;
     let response = ResponseType::new(elective_subject, None);
 
     Ok(HttpResponse::Ok().json(response))

--- a/mysk-lib/src/helpers/date.rs
+++ b/mysk-lib/src/helpers/date.rs
@@ -19,7 +19,7 @@ pub fn get_current_semester(date: Option<NaiveDate>) -> i64 {
         .month();
 
     // If the month is less than july, then it is the first semester
-    if month >= 4 && month < 10 {
+    if (4..10).contains(&month) {
         1
     } else {
         2

--- a/mysk-lib/src/models/elective_subject/db.rs
+++ b/mysk-lib/src/models/elective_subject/db.rs
@@ -15,7 +15,7 @@ use chrono::{DateTime, Utc};
 use mysk_lib_derives::{BaseQuery, GetById};
 use mysk_lib_macros::traits::db::{BaseQuery, GetById};
 use serde::{Deserialize, Serialize};
-use sqlx::{query, FromRow, PgPool, Postgres, QueryBuilder, Row};
+use sqlx::{query, Execute, FromRow, PgPool, Postgres, QueryBuilder, Row};
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow, BaseQuery, GetById)]
@@ -181,6 +181,8 @@ impl QueryDb<QueryableElectiveSubject, SortableElectiveSubject> for DbElectiveSu
                 }
             }
         }
+
+        // dbg!(&query.build_query_as::<DbElectiveSubject>().sql());
 
         query
             .build_query_as::<DbElectiveSubject>()

--- a/mysk-lib/src/models/elective_subject/db.rs
+++ b/mysk-lib/src/models/elective_subject/db.rs
@@ -43,6 +43,7 @@ pub struct DbElectiveSubject {
     pub semester: Option<i64>,
     pub subject_group_id: i64,
     pub syllabus: Option<String>,
+    pub session_code: i64,
 }
 
 impl DbElectiveSubject {

--- a/mysk-lib/src/models/elective_subject/db.rs
+++ b/mysk-lib/src/models/elective_subject/db.rs
@@ -1,16 +1,14 @@
 use super::request::{queryable::QueryableElectiveSubject, sortable::SortableElectiveSubject};
 use crate::{
     common::{
-        requests::{
-            FetchLevel, FilterConfig, PaginationConfig, QueryParam, SortingConfig, SqlSection,
-        },
+        requests::{FilterConfig, PaginationConfig, QueryParam, SortingConfig, SqlSection},
         response::PaginationType,
     },
     helpers::date::get_current_academic_year,
     models::{
-        student::{db::DbStudent, Student},
+        student::db::DbStudent,
         subject::enums::subject_type::SubjectType,
-        traits::{QueryDb, Queryable, TopLevelGetById},
+        traits::{QueryDb, Queryable},
     },
     prelude::*,
 };

--- a/mysk-lib/src/models/elective_subject/fetch_levels/compact.rs
+++ b/mysk-lib/src/models/elective_subject/fetch_levels/compact.rs
@@ -15,6 +15,7 @@ pub struct CompactElectiveSubject {
     pub short_name: MultiLangString,
     pub class_size: i64,
     pub cap_size: i64,
+    pub session_code: i64,
 }
 
 impl From<DbElectiveSubject> for CompactElectiveSubject {
@@ -29,6 +30,7 @@ impl From<DbElectiveSubject> for CompactElectiveSubject {
             ),
             class_size: subject.class_size,
             cap_size: subject.cap_size,
+            session_code: subject.session_code,
         }
     }
 }

--- a/mysk-lib/src/models/elective_subject/fetch_levels/default.rs
+++ b/mysk-lib/src/models/elective_subject/fetch_levels/default.rs
@@ -33,6 +33,7 @@ pub struct DefaultElectiveSubject {
     pub room: String,
     pub r#type: SubjectType,
     pub semester: Option<i64>,
+    pub session_code: i64,
 }
 
 impl FetchLevelVariant<DbElectiveSubject> for DefaultElectiveSubject {
@@ -95,6 +96,7 @@ impl FetchLevelVariant<DbElectiveSubject> for DefaultElectiveSubject {
             class_size: table.class_size,
             cap_size: table.cap_size,
             room: table.room,
+            session_code: table.session_code,
         })
     }
 }

--- a/mysk-lib/src/models/elective_subject/fetch_levels/detailed.rs
+++ b/mysk-lib/src/models/elective_subject/fetch_levels/detailed.rs
@@ -37,6 +37,7 @@ pub struct DetailedElectiveSubject {
     pub semester: Option<i64>,
     pub applicable_classrooms: Vec<Classroom>,
     pub students: Vec<Student>,
+    pub session_code: i64,
 }
 
 impl FetchLevelVariant<DbElectiveSubject> for DetailedElectiveSubject {
@@ -115,6 +116,7 @@ impl FetchLevelVariant<DbElectiveSubject> for DetailedElectiveSubject {
                 Some(&FetchLevel::IdOnly),
             )
             .await?,
+            session_code: table.session_code,
         })
     }
 }

--- a/mysk-lib/src/models/elective_subject/mod.rs
+++ b/mysk-lib/src/models/elective_subject/mod.rs
@@ -1,3 +1,5 @@
+use uuid::Uuid;
+
 use self::{
     db::DbElectiveSubject,
     fetch_levels::{
@@ -51,6 +53,40 @@ impl ElectiveSubject {
             None => Err(Error::EntityNotFound(
                 "Elective subject with given session code does not exist".to_string(),
                 "ElectiveSubject::get_by_session_code".to_string(),
+            )),
+        }
+    }
+    /// # Get elective subject by id with student context
+    /// This function is the extension of the `get_by_id` function
+    ///
+    /// Since an elective subject can be enrolled by students in different classrooms and taught in different sessions
+    ///
+    /// This function will return the elective subject object which is available for the student which will always be unique
+    ///
+    /// If the student is not eligible for the elective subject, it will return None
+    ///
+    /// If the student is not in any classroom, it will return an error
+    pub async fn get_by_id_with_student_context(
+        pool: &sqlx::PgPool,
+        id: Uuid,
+        student_id: Uuid,
+        fetch_level: Option<&FetchLevel>,
+        descendant_fetch_level: Option<&FetchLevel>,
+    ) -> Result<Self> {
+        let elective =
+            DbElectiveSubject::get_by_id_with_student_context(pool, id, student_id).await?;
+        match elective {
+            Some(elective) => Ok(ElectiveSubject::from_table(
+                pool,
+                elective,
+                fetch_level,
+                descendant_fetch_level,
+            )
+            .await?),
+            None => Err(Error::EntityNotFound(
+                "Elective subject with given id does not exist or is not eligible for the student"
+                    .to_string(),
+                "ElectiveSubject::get_by_id".to_string(),
             )),
         }
     }

--- a/mysk-lib/src/models/elective_subject/mod.rs
+++ b/mysk-lib/src/models/elective_subject/mod.rs
@@ -56,6 +56,7 @@ impl ElectiveSubject {
             )),
         }
     }
+
     /// # Get elective subject by id with student context
     /// This function is the extension of the `get_by_id` function
     ///

--- a/mysk-lib/src/models/elective_subject/mod.rs
+++ b/mysk-lib/src/models/elective_subject/mod.rs
@@ -6,7 +6,13 @@ use self::{
     },
     request::{queryable::QueryableElectiveSubject, sortable::SortableElectiveSubject},
 };
-use crate::models::{top_level_variant::TopLevelVariant, traits::TopLevelQuery};
+use crate::{
+    common::requests::FetchLevel,
+    models::{top_level_variant::TopLevelVariant, traits::TopLevelQuery},
+    prelude::*,
+};
+
+use super::traits::TopLevelFromTable;
 
 pub mod db;
 pub mod fetch_levels;
@@ -23,4 +29,29 @@ pub type ElectiveSubject = TopLevelVariant<
 impl TopLevelQuery<DbElectiveSubject, QueryableElectiveSubject, SortableElectiveSubject>
     for ElectiveSubject
 {
+}
+
+impl ElectiveSubject {
+    pub async fn get_by_session_code(
+        pool: &sqlx::PgPool,
+        session_code: i64,
+        fetch_level: Option<&FetchLevel>,
+        descendant_fetch_level: Option<&FetchLevel>,
+    ) -> Result<Self> {
+        let elective = DbElectiveSubject::get_by_session_code(pool, session_code).await?;
+
+        match elective {
+            Some(elective) => Ok(ElectiveSubject::from_table(
+                pool,
+                elective,
+                fetch_level,
+                descendant_fetch_level,
+            )
+            .await?),
+            None => Err(Error::EntityNotFound(
+                "Elective subject with given session code does not exist".to_string(),
+                "ElectiveSubject::get_by_session_code".to_string(),
+            )),
+        }
+    }
 }

--- a/mysk-lib/src/models/elective_subject/request/queryable.rs
+++ b/mysk-lib/src/models/elective_subject/request/queryable.rs
@@ -171,8 +171,7 @@ impl Queryable for QueryableElectiveSubject {
             // WHERE id IN (SELECT elective_subject_id FROM elective_subject_classrooms WHERE classroom_id IN (SELECT classroom_id FROM classroom_students INNER JOIN classrooms ON classrooms.id = classroom_students.classroom_id WHERE student_id = $1 AND year = $2))
             where_sections.push(SqlSection {
                 sql: vec![
-                    "id IN (SELECT elective_subject_id FROM elective_subject_classrooms".to_string(),
-                    " WHERE classroom_id IN (SELECT classroom_id FROM classroom_students INNER JOIN classrooms ON classrooms.id = classroom_students.classroom_id WHERE student_id = ".to_string(),
+                    "session_code IN (SELECT session_code FROM elective_subject_classrooms WHERE classroom_id IN (SELECT classroom_id FROM classroom_students INNER JOIN classrooms ON classrooms.id = classroom_students.classroom_id WHERE student_id = ".to_string(),
                     " AND year = ".to_string(),
                     "))".to_string(),
                 ],


### PR DESCRIPTION
**Features**
- Use `session_code` instead of `id` to get unique and `ElectiveSubject` in basic endpoints
- `ElectiveSubject::get_by_session_code` helper function

**Fixes**
- Changing elective subject doesn't check if the student has an elective or not
- Enrolling or changing elective subject doesn't  separate the cap_size for each `session_code` 
