### PR TITLE
Beta Release 0.2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,22 +10,25 @@
 <br />
 
 ## 📦 Setup
-1) To get set up, clone the repository and ensure that hese tools & dependencies are installed on your system
+
+1) To get set up, clone the repository and ensure that these tools & dependencies are installed on your system
     - [rust](https://rustup.rs/)
     - [npm](https://www.npmjs.com/)
     - [mprocs](https://github.com/pvolok/mprocs) (see [using-mprocs](#🛠️-using-mprocs))
     - git🙄
 
 2) Run the following command in `/mysk-api-test-web-server`
+
 ```sh
 # install dependencies for the API client server
 $ npm i
 ```
 
 ### :herb: Environment
-| File                                                                                                                             | Description                   |
-| -------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| [`.env`](.env.template)                                      | Global configuration file     |
+
+| File                                                                                  | Description                   |
+| ------------------------------------------------------------------------------------- | ----------------------------- |
+| [`.env`](.env.template)                                                               | Global configuration file     |
 | [`mysk-api-test-web-server/.env.local`](mysk-api-test-web-server/.env.local.template) | Web server configuration file |
 
 > [!CAUTION]
@@ -34,15 +37,20 @@ $ npm i
 <br />
 
 ## 🚀 Development
+
 ### 🛠️ Using mprocs
+
 If [mprocs](https://github.com/pvolok/mprocs) is installed, run the following command:
+
 ```sh
 # This command will look for an mprocs.yaml configuration and start necessary services automatically
 $ mprocs --config ./mprocs.yaml
 ```
 
 ### ⚙️  Manually
+
 To start services manually run the following commands:
+
 ```sh
 # Build and run cargo workspace at root
 $ cargo run
@@ -54,7 +62,9 @@ $ npm run dev
 <br />
 
 ### 📁 Basic structure
+
 This repository contains libraries and tools needed to get set up for developing on MySK's API. The basic structure of the monorepo are as follows:
+
 ```
 .
 ├── mysk-api-test-web-server                                            // testing client
@@ -68,4 +78,3 @@ This repository contains libraries and tools needed to get set up for developing
 ├── mysk-lib/                                                           // libraries
 └── Cargo.toml                                                          // cargo workspace
 ```
-

--- a/mysk-api-test-web-server/utils/helpers/useOneTapSignin.ts
+++ b/mysk-api-test-web-server/utils/helpers/useOneTapSignin.ts
@@ -62,7 +62,7 @@ export const useOneTapSignin = (options?: {
             callback: async (response) => {
               const { data: BackendCredentials, error } =
                 await fetchAPI<BackendCredentials>(
-                  "/auth/oauth/google",
+                  "/auth/oauth/gsi",
                   undefined,
                   {
                     method: "POST",

--- a/mysk-data-api/Cargo.toml
+++ b/mysk-data-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mysk-data-api"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/mysk-data-api/src/extractors/logged_in.rs
+++ b/mysk-data-api/src/extractors/logged_in.rs
@@ -4,7 +4,6 @@ use actix_web::{dev::Payload, http::header, web::Data, FromRequest, HttpRequest}
 use futures::future;
 use jsonwebtoken::{decode, DecodingKey, Validation};
 use mysk_lib::{auth::oauth::TokenClaims, models::user::User, prelude::*};
-use mysk_lib_macros::traits::db::GetById;
 use serde::Serialize;
 use uuid::Uuid;
 

--- a/mysk-data-api/src/routes/v1/subjects/electives/enroll_electives.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/enroll_electives.rs
@@ -94,7 +94,7 @@ pub async fn enroll_elective_subject(
         SELECT 
             COUNT(*) 
         FROM 
-            elective_subject_session_enrolled_students 
+            elective_subject_session_enrolled_students enrolls
             INNER JOIN elective_subject_sessions electives
             ON enrolls.elective_subject_session_id = electives.id
         WHERE student_id = $1 AND subject_id = $2

--- a/mysk-data-api/src/routes/v1/subjects/electives/enroll_electives.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/enroll_electives.rs
@@ -13,30 +13,35 @@ use mysk_lib::{
         response::ResponseType,
     },
     helpers::date::{get_current_academic_year, get_current_semester},
-    models::elective_subject::{db::DbElectiveSubject, ElectiveSubject},
+    models::{
+        elective_subject::{db::DbElectiveSubject, ElectiveSubject},
+        traits::TopLevelGetById,
+    },
     prelude::*,
 };
+use mysk_lib_macros::traits::db::GetById;
 use sqlx::query;
+use uuid::Uuid;
 
 #[allow(clippy::too_many_lines)]
-#[post("/{session_code}/enroll")]
+#[post("/{id}/enroll")]
 pub async fn enroll_elective_subject(
     data: Data<AppState>,
-    session_code: Path<i64>,
+    elective_subject_session_id: Path<Uuid>,
     student_id: LoggedInStudent,
     request_body: Json<RequestType<ElectiveSubject, QueryablePlaceholder, SortablePlaceholder>>,
     _: ApiKeyHeader,
 ) -> Result<impl Responder> {
     let pool = &data.db;
     let student_id = student_id.0;
-    let session_code = session_code.into_inner();
+    let elective_subject_session_id = elective_subject_session_id.into_inner();
     let fetch_level = request_body.fetch_level.as_ref();
     let descendant_fetch_level = request_body.descendant_fetch_level.as_ref();
 
     // Checks if the elective the student is trying to enroll in is available
-    let elective = match ElectiveSubject::get_by_session_code(
+    let elective = match ElectiveSubject::get_by_id(
         pool,
-        session_code,
+        elective_subject_session_id,
         Some(&FetchLevel::Detailed),
         None,
     )
@@ -46,7 +51,7 @@ pub async fn enroll_elective_subject(
             if elective.class_size == elective.cap_size {
                 return Err(Error::InvalidPermission(
                     "The elective is already full".to_string(),
-                    format!("/subjects/electives/{session_code}/enroll"),
+                    format!("/subjects/electives/{elective_subject_session_id}/enroll"),
                 ));
             }
 
@@ -55,7 +60,7 @@ pub async fn enroll_elective_subject(
         Err(Error::InternalSeverError(_, _)) => {
             return Err(Error::EntityNotFound(
                 "Elective subject not found".to_string(),
-                format!("/subjects/electives/{session_code}/enroll"),
+                format!("/subjects/electives/{elective_subject_session_id}/enroll"),
             ));
         }
         _ => unreachable!("ElectiveSubject::get_by_id should always return a Detailed variant"),
@@ -65,35 +70,45 @@ pub async fn enroll_elective_subject(
     if !DbElectiveSubject::is_enrollment_period(pool).await? {
         return Err(Error::InvalidPermission(
             "The elective's enrollment period has ended".to_string(),
-            format!("/subjects/electives/{session_code}/enroll"),
+            format!("/subjects/electives/{elective_subject_session_id}/enroll"),
         ));
     }
 
     // Checks if the student is in a class available for the elective
-    if !DbElectiveSubject::is_student_eligible(pool, session_code, student_id).await? {
+    if !DbElectiveSubject::is_student_eligible(pool, elective_subject_session_id, student_id)
+        .await?
+    {
         return Err(Error::InvalidPermission(
             "Student is not eligible to enroll in this elective".to_string(),
-            format!("/subjects/electives/{session_code}/enroll"),
+            format!("/subjects/electives/{elective_subject_session_id}/enroll"),
         ));
     }
 
     // Checks if the student has already enrolled in the elective before
+    let subject_id = DbElectiveSubject::get_by_id(pool, elective_subject_session_id)
+        .await?
+        .subject_id;
+
     let enroll_count = query!(
         r"
-        SELECT COUNT(*) FROM student_elective_subjects
-        WHERE student_id = $1 AND elective_subject_id = $2
+        SELECT 
+            COUNT(*) 
+        FROM 
+            elective_subject_session_enrolled_students 
+            INNER JOIN elective_subject_sessions_with_detail_view on elective_subject_session_enrolled_students.elective_subject_session_id = elective_subject_sessions_with_detail_view.id
+        WHERE student_id = $1 AND subject_id = $2
         ",
         student_id,
-        elective.id
+        subject_id,
     )
     .fetch_one(pool)
-    .await?
-    .count
-    .unwrap_or(0);
+    .await?;
+
+    let enroll_count: i64 = enroll_count.count.unwrap_or(0);
     if enroll_count > 0 {
         return Err(Error::InvalidPermission(
             "Student has already enrolled in this elective before".to_string(),
-            format!("/subjects/electives/{session_code}/enroll"),
+            format!("/subjects/electives/{elective_subject_session_id}/enroll"),
         ));
     }
 
@@ -101,8 +116,8 @@ pub async fn enroll_elective_subject(
     let has_enrolled = query!(
         r"
         SELECT EXISTS (
-            SELECT FROM student_elective_subjects
-            WHERE student_id = $1 AND year = $2 AND semester = $3
+            SELECT elective_subject_session_id FROM elective_subject_session_enrolled_students INNER JOIN elective_subject_sessions ON elective_subject_session_enrolled_students.elective_subject_session_id = elective_subject_sessions.id
+            WHERE student_id = $1 and year = $2 AND semester = $3
         )
         ",
         student_id,
@@ -116,28 +131,24 @@ pub async fn enroll_elective_subject(
     if has_enrolled {
         return Err(Error::InvalidPermission(
             "Student has already enrolled in an elective this semester".to_string(),
-            format!("/subjects/electives/{session_code}/enroll"),
+            format!("/subjects/electives/{elective_subject_session_id}/enroll"),
         ));
     }
 
     query!(
         r"
-        INSERT INTO student_elective_subjects (
-            student_id, elective_subject_id, year, semester
-        ) VALUES ($1, $2, $3, $4)
+        INSERT INTO elective_subject_session_enrolled_students (student_id, elective_subject_session_id)  VALUES ($1, $2) ON CONFLICT DO NOTHING
         ",
         student_id,
         elective.id,
-        get_current_academic_year(None),
-        get_current_semester(None),
     )
     .execute(pool)
     .await?;
 
     // Get the elective subject by session code with the fetch levels requested to return the response
-    let elective = ElectiveSubject::get_by_session_code(
+    let elective = ElectiveSubject::get_by_id(
         pool,
-        session_code,
+        elective_subject_session_id,
         fetch_level,
         descendant_fetch_level,
     )

--- a/mysk-data-api/src/routes/v1/subjects/electives/enroll_electives.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/enroll_electives.rs
@@ -95,7 +95,8 @@ pub async fn enroll_elective_subject(
             COUNT(*) 
         FROM 
             elective_subject_session_enrolled_students 
-            INNER JOIN elective_subject_sessions_with_detail_view on elective_subject_session_enrolled_students.elective_subject_session_id = elective_subject_sessions_with_detail_view.id
+            INNER JOIN elective_subject_sessions electives
+            ON enrolls.elective_subject_session_id = electives.id
         WHERE student_id = $1 AND subject_id = $2
         ",
         student_id,

--- a/mysk-data-api/src/routes/v1/subjects/electives/modify_electives.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/modify_electives.rs
@@ -115,7 +115,8 @@ async fn modify_elective_subject(
             COUNT(*) 
         FROM 
             elective_subject_session_enrolled_students 
-            INNER JOIN elective_subject_sessions_with_detail_view on elective_subject_session_enrolled_students.elective_subject_session_id = elective_subject_sessions_with_detail_view.id
+            INNER JOIN elective_subject_sessions electives
+            ON enrolls.elective_subject_session_id = electives.id
         WHERE student_id = $1 AND subject_id = $2
         ",
         student_id,

--- a/mysk-data-api/src/routes/v1/subjects/electives/modify_electives.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/modify_electives.rs
@@ -114,7 +114,7 @@ async fn modify_elective_subject(
         SELECT 
             COUNT(*) 
         FROM 
-            elective_subject_session_enrolled_students 
+            elective_subject_session_enrolled_students enrolls
             INNER JOIN elective_subject_sessions electives
             ON enrolls.elective_subject_session_id = electives.id
         WHERE student_id = $1 AND subject_id = $2

--- a/mysk-data-api/src/routes/v1/subjects/electives/query_elective_details.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/query_elective_details.rs
@@ -9,24 +9,30 @@ use mysk_lib::{
         requests::{QueryablePlaceholder, RequestType, SortablePlaceholder},
         response::ResponseType,
     },
-    models::elective_subject::ElectiveSubject,
+    models::{elective_subject::ElectiveSubject, traits::TopLevelGetById},
     prelude::*,
 };
+use uuid::Uuid;
 
-#[get("/{session_code}")]
+#[get("/{id}")]
 pub async fn query_elective_details(
     data: Data<AppState>,
-    path: Path<i64>,
+    elective_subject_session_id: Path<Uuid>,
     request_query: RequestType<ElectiveSubject, QueryablePlaceholder, SortablePlaceholder>,
     _: ApiKeyHeader,
 ) -> Result<impl Responder> {
     let pool = &data.db;
-    let id = path.into_inner();
+    let elective_subject_session_id = elective_subject_session_id.into_inner();
     let fetch_level = request_query.fetch_level.as_ref();
     let descendant_fetch_level = request_query.descendant_fetch_level.as_ref();
 
-    let elective_subject =
-        ElectiveSubject::get_by_session_code(pool, id, fetch_level, descendant_fetch_level).await?;
+    let elective_subject = ElectiveSubject::get_by_id(
+        pool,
+        elective_subject_session_id,
+        fetch_level,
+        descendant_fetch_level,
+    )
+    .await?;
     let response = ResponseType::new(elective_subject, None);
 
     Ok(HttpResponse::Ok().json(response))

--- a/mysk-data-api/src/routes/v1/subjects/electives/trade_offers/create_offer.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/trade_offers/create_offer.rs
@@ -60,7 +60,7 @@ async fn create_trade_offer(
     // Check if the receiving student has an elective subject
     let Some(receiver_elective_subject_id) = query!(
         r"
-        SELECT elective_subject_id FROM student_elective_subjects
+        SELECT elective_subject_session_id FROM elective_subject_session_enrolled_students INNER JOIN elective_subject_sessions ON elective_subject_session_enrolled_students.elective_subject_session_id = elective_subject_sessions.id
         WHERE student_id = $1 and year = $2 AND semester = $3
         ",
         receiver_student_id,
@@ -75,13 +75,12 @@ async fn create_trade_offer(
             "/subjects/electives/trade-offers".to_string(),
         ));
     };
-    let receiver_elective_subject_id = receiver_elective_subject_id.elective_subject_id;
+    let receiver_elective_subject_id = receiver_elective_subject_id.elective_subject_session_id;
 
     // Gets the elective subject of the receiver, and also checks whether they're in a classroom
-    let receiver_elective_subject = match ElectiveSubject::get_by_id_with_student_context(
+    let receiver_elective_subject = match ElectiveSubject::get_by_id(
         pool,
         receiver_elective_subject_id,
-        receiver_student_id,
         Some(&FetchLevel::Compact),
         None,
     )
@@ -113,7 +112,7 @@ async fn create_trade_offer(
     // whether they're in a classroom
     match DbElectiveSubject::is_student_eligible(
         pool,
-        receiver_elective_subject.session_code,
+        receiver_elective_subject.id,
         sender_student_id,
     )
     .await
@@ -137,7 +136,7 @@ async fn create_trade_offer(
     // Check if the sending student has an elective subject
     let Some(sender_elective_subject_id) = query!(
         r"
-        SELECT elective_subject_id FROM student_elective_subjects
+        SELECT elective_subject_session_id FROM elective_subject_session_enrolled_students INNER JOIN elective_subject_sessions ON elective_subject_session_enrolled_students.elective_subject_session_id = elective_subject_sessions.id
         WHERE student_id = $1 and year = $2 AND semester = $3
         ",
         sender_student_id,
@@ -152,13 +151,12 @@ async fn create_trade_offer(
             "/subjects/electives/trade-offers".to_string(),
         ));
     };
-    let sender_elective_subject_id = sender_elective_subject_id.elective_subject_id;
+    let sender_elective_subject_id = sender_elective_subject_id.elective_subject_session_id;
 
     // Gets the elective subject of the sender
-    let sender_elective_subject = match ElectiveSubject::get_by_id_with_student_context(
+    let sender_elective_subject = match ElectiveSubject::get_by_id(
         pool,
         sender_elective_subject_id,
-        sender_student_id,
         Some(&FetchLevel::Compact),
         None,
     )
@@ -183,7 +181,7 @@ async fn create_trade_offer(
     // Checks if the receiver is eligible to enroll in the sender's elective session
     match DbElectiveSubject::is_student_eligible(
         pool,
-        sender_elective_subject.session_code,
+        sender_elective_subject.id,
         receiver_student_id,
     )
     .await
@@ -214,7 +212,7 @@ async fn create_trade_offer(
         SELECT EXISTS (
             SELECT FROM elective_subject_trade_offers
             WHERE sender_id = $1 AND receiver_id = $2 AND status = $3
-            AND sender_elective_subject_id = $4 AND receiver_elective_subject_id = $5
+            AND sender_elective_subject_session_id = $4 AND receiver_elective_subject_session_id = $5
         )
         ",
         sender_student_id,
@@ -240,8 +238,8 @@ async fn create_trade_offer(
             sender_id,
             receiver_id,
             status,
-            sender_elective_subject_id,
-            receiver_elective_subject_id
+            sender_elective_subject_session_id,
+            receiver_elective_subject_session_id
         ) VALUES ($1, $2, $3, $4, $5)
         RETURNING id
         ",

--- a/mysk-data-api/src/routes/v1/subjects/electives/trade_offers/update_offer.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/trade_offers/update_offer.rs
@@ -75,8 +75,8 @@ async fn update_trade_offer(
             sender_id,
             receiver_id,
             status AS "status: SubmissionStatus",
-            sender_elective_subject_id,
-            receiver_elective_subject_id
+            sender_elective_subject_session_id,
+            receiver_elective_subject_session_id
         FROM elective_subject_trade_offers WHERE id = $1
         "#,
         trade_offer_id,

--- a/mysk-lib-derives/Cargo.toml
+++ b/mysk-lib-derives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mysk-lib-derives"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/mysk-lib-macros/Cargo.toml
+++ b/mysk-lib-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mysk-lib-macros"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/mysk-lib/Cargo.toml
+++ b/mysk-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mysk-lib"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/mysk-lib/src/auth/oauth.rs
+++ b/mysk-lib/src/auth/oauth.rs
@@ -1,6 +1,6 @@
 use crate::{common::config::Config, prelude::*};
 use rand::{rngs::OsRng, RngCore};
-use reqwest::Client;
+use reqwest::{Client, header::{HeaderValue, CONTENT_LENGTH}};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
@@ -156,6 +156,7 @@ pub async fn exchange_oauth_code(
             "https://oauth2.googleapis.com/token?{}",
             serde_qs::to_string(&query_params).unwrap(),
         ))
+        .header(CONTENT_LENGTH, HeaderValue::from_static("0"))
         .send()
         .await;
 

--- a/mysk-lib/src/models/elective_subject/db.rs
+++ b/mysk-lib/src/models/elective_subject/db.rs
@@ -15,7 +15,7 @@ use chrono::{DateTime, Utc};
 use mysk_lib_derives::{BaseQuery, GetById};
 use mysk_lib_macros::traits::db::{BaseQuery, GetById};
 use serde::{Deserialize, Serialize};
-use sqlx::{query, query_as, FromRow, PgPool, Postgres, QueryBuilder, Row as _};
+use sqlx::{query, FromRow, PgPool, Postgres, QueryBuilder, Row as _};
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow, BaseQuery, GetById)]
@@ -47,24 +47,6 @@ pub struct DbElectiveSubject {
 }
 
 impl DbElectiveSubject {
-    pub async fn get_by_session_code(pool: &PgPool, session_code: i64) -> Result<Option<Self>> {
-        query_as::<_, DbElectiveSubject>(
-            r"
-            SELECT * FROM elective_subject_sessions_with_detail
-            WHERE session_code = $1
-            ",
-        )
-        .bind(session_code)
-        .fetch_optional(pool)
-        .await
-        .map_err(|e| {
-            Error::InternalSeverError(
-                e.to_string(),
-                "DbElectiveSubject::get_by_session_code".to_string(),
-            )
-        })
-    }
-
     /// Checks if the student is in a class available for the elective
     pub async fn is_student_eligible(
         pool: &PgPool,

--- a/mysk-lib/src/models/elective_subject/db.rs
+++ b/mysk-lib/src/models/elective_subject/db.rs
@@ -4,7 +4,6 @@ use crate::{
         requests::{FilterConfig, PaginationConfig, QueryParam, SortingConfig, SqlSection},
         response::PaginationType,
     },
-    helpers::date::{get_current_academic_year, get_current_semester},
     models::{
         student::db::DbStudent,
         subject::enums::subject_type::SubjectType,

--- a/mysk-lib/src/models/elective_subject/db.rs
+++ b/mysk-lib/src/models/elective_subject/db.rs
@@ -43,7 +43,7 @@ pub struct DbElectiveSubject {
     pub semester: Option<i64>,
     pub subject_group_id: i64,
     pub syllabus: Option<String>,
-    pub session_code: i64,
+    pub session_code: String,
 }
 
 impl DbElectiveSubject {

--- a/mysk-lib/src/models/elective_subject/fetch_levels/compact.rs
+++ b/mysk-lib/src/models/elective_subject/fetch_levels/compact.rs
@@ -15,7 +15,7 @@ pub struct CompactElectiveSubject {
     pub short_name: MultiLangString,
     pub class_size: i64,
     pub cap_size: i64,
-    pub session_code: i64,
+    pub session_code: String,
 }
 
 impl From<DbElectiveSubject> for CompactElectiveSubject {

--- a/mysk-lib/src/models/elective_subject/fetch_levels/default.rs
+++ b/mysk-lib/src/models/elective_subject/fetch_levels/default.rs
@@ -98,7 +98,7 @@ impl FetchLevelVariant<DbElectiveSubject> for DefaultElectiveSubject {
             cap_size: table.cap_size,
             room: table.room,
             session_code: table.session_code,
-            requirements: DbElectiveSubject::get_requirements(pool, table.id).await?,
+            requirements: DbSubject::get_requirements(pool, table.subject_id).await?,
         })
     }
 }

--- a/mysk-lib/src/models/elective_subject/fetch_levels/default.rs
+++ b/mysk-lib/src/models/elective_subject/fetch_levels/default.rs
@@ -33,7 +33,7 @@ pub struct DefaultElectiveSubject {
     pub room: String,
     pub r#type: SubjectType,
     pub semester: Option<i64>,
-    pub session_code: i64,
+    pub session_code: String,
     pub requirements: Vec<MultiLangString>,
 }
 

--- a/mysk-lib/src/models/elective_subject/fetch_levels/detailed.rs
+++ b/mysk-lib/src/models/elective_subject/fetch_levels/detailed.rs
@@ -38,7 +38,7 @@ pub struct DetailedElectiveSubject {
     pub applicable_classrooms: Vec<Classroom>,
     pub students: Vec<Student>,
     pub randomized_students: Vec<Student>,
-    pub session_code: i64,
+    pub session_code: String,
     pub requirements: Vec<MultiLangString>,
 }
 

--- a/mysk-lib/src/models/elective_subject/fetch_levels/detailed.rs
+++ b/mysk-lib/src/models/elective_subject/fetch_levels/detailed.rs
@@ -55,8 +55,8 @@ impl FetchLevelVariant<DbElectiveSubject> for DetailedElectiveSubject {
         let co_teacher_ids =
             DbSubject::get_subject_co_teachers(pool, table.subject_id, None).await?;
         let applicable_classroom_ids = table.get_subject_applicable_classrooms(pool).await?;
-        let student_ids = table.get_enrolled_students(pool, None, None).await?;
-        let randomized_student_ids = table.get_randomized_student(pool, None, None).await?;
+        let student_ids = table.get_enrolled_students(pool).await?;
+        let randomized_student_ids = table.get_randomized_student(pool).await?;
 
         let description = match (table.description_th, table.description_en) {
             (Some(description_th), Some(description_en)) => Some(FlexibleMultiLangString {
@@ -120,7 +120,7 @@ impl FetchLevelVariant<DbElectiveSubject> for DetailedElectiveSubject {
             )
             .await?,
             session_code: table.session_code,
-            requirements: DbElectiveSubject::get_requirements(pool, table.id).await?,
+            requirements: DbSubject::get_requirements(pool, table.id).await?,
             randomized_students: Student::get_by_ids(
                 pool,
                 randomized_student_ids,

--- a/mysk-lib/src/models/elective_subject/mod.rs
+++ b/mysk-lib/src/models/elective_subject/mod.rs
@@ -1,5 +1,3 @@
-use uuid::Uuid;
-
 use self::{
     db::DbElectiveSubject,
     fetch_levels::{
@@ -53,37 +51,6 @@ impl ElectiveSubject {
             None => Err(Error::EntityNotFound(
                 "Elective subject with given session code does not exist".to_string(),
                 "ElectiveSubject::get_by_session_code".to_string(),
-            )),
-        }
-    }
-
-    /// # Get elective subject by ID with student context
-    /// This function is the extension of the `get_by_id` function. Since an elective subject can
-    /// be enrolled by students in different classrooms and taught in different sessions, this
-    /// function will return the elective subject object which is available for the student which
-    /// will always be unique. If the student is not eligible for the elective subject, it will
-    /// return `None`. If the student is not in any classroom, it will return an `Error`.
-    pub async fn get_by_id_with_student_context(
-        pool: &sqlx::PgPool,
-        id: Uuid,
-        student_id: Uuid,
-        fetch_level: Option<&FetchLevel>,
-        descendant_fetch_level: Option<&FetchLevel>,
-    ) -> Result<Self> {
-        let elective =
-            DbElectiveSubject::get_by_id_with_student_context(pool, id, student_id).await?;
-        match elective {
-            Some(elective) => Ok(ElectiveSubject::from_table(
-                pool,
-                elective,
-                fetch_level,
-                descendant_fetch_level,
-            )
-            .await?),
-            None => Err(Error::EntityNotFound(
-                "Elective subject with given ID does not exist or is not eligible for the student"
-                    .to_string(),
-                "ElectiveSubject::get_by_id".to_string(),
             )),
         }
     }

--- a/mysk-lib/src/models/elective_subject/mod.rs
+++ b/mysk-lib/src/models/elective_subject/mod.rs
@@ -6,13 +6,7 @@ use self::{
     },
     request::{queryable::QueryableElectiveSubject, sortable::SortableElectiveSubject},
 };
-use crate::{
-    common::requests::FetchLevel,
-    models::{top_level_variant::TopLevelVariant, traits::TopLevelQuery},
-    prelude::*,
-};
-
-use super::traits::TopLevelFromTable;
+use crate::models::{top_level_variant::TopLevelVariant, traits::TopLevelQuery};
 
 pub mod db;
 pub mod fetch_levels;
@@ -29,29 +23,4 @@ pub type ElectiveSubject = TopLevelVariant<
 impl TopLevelQuery<DbElectiveSubject, QueryableElectiveSubject, SortableElectiveSubject>
     for ElectiveSubject
 {
-}
-
-impl ElectiveSubject {
-    pub async fn get_by_session_code(
-        pool: &sqlx::PgPool,
-        session_code: i64,
-        fetch_level: Option<&FetchLevel>,
-        descendant_fetch_level: Option<&FetchLevel>,
-    ) -> Result<Self> {
-        let elective = DbElectiveSubject::get_by_session_code(pool, session_code).await?;
-
-        match elective {
-            Some(elective) => Ok(ElectiveSubject::from_table(
-                pool,
-                elective,
-                fetch_level,
-                descendant_fetch_level,
-            )
-            .await?),
-            None => Err(Error::EntityNotFound(
-                "Elective subject with given session code does not exist".to_string(),
-                "ElectiveSubject::get_by_session_code".to_string(),
-            )),
-        }
-    }
 }

--- a/mysk-lib/src/models/elective_subject/request/queryable.rs
+++ b/mysk-lib/src/models/elective_subject/request/queryable.rs
@@ -1,6 +1,5 @@
 use crate::{
     common::requests::{QueryParam, SqlSection},
-    helpers::date::{get_current_academic_year, get_current_semester},
     models::traits::Queryable,
 };
 use serde::{Deserialize, Serialize};
@@ -20,7 +19,6 @@ pub struct QueryableElectiveSubject {
     pub applicable_classroom_ids: Option<Vec<Uuid>>,
     pub room: Option<String>,
     pub student_ids: Option<Vec<Uuid>>,
-    pub as_student_id: Option<Uuid>,
 }
 
 impl Queryable for QueryableElectiveSubject {
@@ -143,13 +141,13 @@ impl Queryable for QueryableElectiveSubject {
             }
         }
 
-        // WHERE session_code IN (SELECT session_code FROM elective_subject_classrooms WHERE
-        // classroom_id IN ANY($1))
+        // WHERE id IN (SELECT elective_subject_session_id FROM elective_subject_session_classrooms WHERE classroom_id IN ANY($1))
         if let Some(applicable_classroom_ids) = &self.applicable_classroom_ids {
             where_sections.push(SqlSection {
                 sql: vec![
-                    "session_code IN (SELECT session_code FROM".to_string(),
-                    " elective_subject_classrooms WHERE classroom_id = ANY())".to_string(),
+                    "id IN (SELECT elective_subject_session_id FROM elective_subject_session_classrooms WHERE classroom_id = ANY("
+                        .to_string(),
+                    "))".to_string(),
                 ],
                 params: vec![QueryParam::ArrayUuid(applicable_classroom_ids.clone())],
             });
@@ -163,56 +161,17 @@ impl Queryable for QueryableElectiveSubject {
             });
         }
 
-        // WHERE id IN (SELECT elective_subject_id FROM student_elective_subjects WHERE student_id
+        // WHERE id IN (SELECT elective_subject_session_id FROM elective_subject_session_enrolled_students WHERE student_id
         // IN ANY($1))
         if let Some(student_ids) = &self.student_ids {
-            // WHERE session_code IN (SELECT session_code FROM elective_subject_classrooms AS esc
-            // INNER JOIN student_elective_subjects AS ses ON
-            // esc.elective_subject_id = ses.elective_subject_id INNER JOIN classroom_students AS
-            // cs ON cs.student_id = ses.student_id WHERE cs.classroom_id = esc.classroom_id AND
-            // ses.student_id = ANY($1) AND year = $2 AND semester = $3)
             where_sections.push(SqlSection {
                 sql: vec![
-                    concat!(
-                        "session_code IN (SELECT session_code FROM elective_subject_classrooms AS",
-                        " esc INNER JOIN student_elective_subjects AS ses ON",
-                        " esc.elective_subject_id = ses.elective_subject_id INNER JOIN",
-                        " classroom_students AS cs ON cs.student_id = ses.student_id WHERE",
-                        " cs.classroom_id = esc.classroom_id AND ses.student_id = ANY(",
-                    )
-                    .to_string(),
-                    ") AND year = ".to_string(),
-                    " AND semester = ".to_string(),
-                    ")".to_string(),
-                ],
-                params: vec![
-                    QueryParam::ArrayUuid(student_ids.clone()),
-                    QueryParam::Int(get_current_academic_year(None)),
-                    QueryParam::Int(get_current_semester(None)),
-                ],
-            });
-        }
-
-        if let Some(as_student_id) = &self.as_student_id {
-            // WHERE id IN (SELECT elective_subject_id FROM elective_subject_classrooms WHERE
-            // classroom_id IN (SELECT classroom_id FROM classroom_students INNER JOIN classrooms
-            // ON classrooms.id = classroom_students.classroom_id WHERE student_id = $1 AND
-            // year = $2))
-            where_sections.push(SqlSection {
-                sql: vec![
-                    concat!(
-                        "session_code IN (SELECT session_code FROM elective_subject_classrooms",
-                        " WHERE classroom_id IN (SELECT classroom_id FROM classroom_students",
-                        " INNER JOIN classrooms ON classrooms.id = classroom_students.classroom_id",
-                        " WHERE student_id = ",
-                    )
-                    .to_string(),
-                    " AND year = ".to_string(),
+                    "id IN (SELECT elective_subject_session_id FROM elective_subject_session_enrolled_students WHERE student_id = ANY("
+                        .to_string(),
                     "))".to_string(),
                 ],
                 params: vec![
-                    QueryParam::Uuid(*as_student_id),
-                    QueryParam::Int(get_current_academic_year(None)),
+                    QueryParam::ArrayUuid(student_ids.clone()),
                 ],
             });
         }

--- a/mysk-lib/src/models/elective_trade_offer/db.rs
+++ b/mysk-lib/src/models/elective_trade_offer/db.rs
@@ -30,8 +30,8 @@ pub struct DbElectiveTradeOffer {
     pub sender_id: Uuid,
     pub receiver_id: Uuid,
     pub status: SubmissionStatus,
-    pub sender_elective_subject_id: Uuid,
-    pub receiver_elective_subject_id: Uuid,
+    pub sender_elective_subject_session_id: Uuid,
+    pub receiver_elective_subject_session_id: Uuid,
 }
 
 impl QueryDb<QueryableElectiveTradeOffer, SortableElectiveTradeOffer> for DbElectiveTradeOffer {

--- a/mysk-lib/src/models/elective_trade_offer/fetch_levels/default.rs
+++ b/mysk-lib/src/models/elective_trade_offer/fetch_levels/default.rs
@@ -47,14 +47,14 @@ impl FetchLevelVariant<DbElectiveTradeOffer> for DefaultElectiveTradeOffer {
             .await?,
             sender_elective_subject: ElectiveSubject::get_by_id(
                 pool,
-                table.sender_elective_subject_id,
+                table.sender_elective_subject_session_id,
                 descendant_fetch_level,
                 Some(&FetchLevel::IdOnly),
             )
             .await?,
             receiver_elective_subject: ElectiveSubject::get_by_id(
                 pool,
-                table.receiver_elective_subject_id,
+                table.receiver_elective_subject_session_id,
                 descendant_fetch_level,
                 Some(&FetchLevel::IdOnly),
             )

--- a/mysk-lib/src/models/student/db.rs
+++ b/mysk-lib/src/models/student/db.rs
@@ -43,7 +43,7 @@ pub struct DbStudent {
     pub shirt_size: Option<ShirtSize>,
     pub blood_group: Option<BloodGroup>,
     pub sex: Sex,
-    pub student_id: String,
+    pub student_id: Option<String>,
     pub user_id: Option<Uuid>,
 }
 

--- a/mysk-lib/src/models/student/fetch_levels/compact.rs
+++ b/mysk-lib/src/models/student/fetch_levels/compact.rs
@@ -15,7 +15,7 @@ pub struct CompactStudent {
     pub first_name: MultiLangString,
     pub last_name: MultiLangString,
     pub nickname: Option<MultiLangString>,
-    pub student_id: String,
+    pub student_id: Option<String>,
     pub profile_url: Option<String>,
 }
 

--- a/mysk-lib/src/models/student/fetch_levels/default.rs
+++ b/mysk-lib/src/models/student/fetch_levels/default.rs
@@ -23,7 +23,7 @@ pub struct DefaultStudent {
     pub middle_name: Option<MultiLangString>,
     pub last_name: MultiLangString,
     pub nickname: Option<MultiLangString>,
-    pub student_id: String,
+    pub student_id: Option<String>,
     pub profile_url: Option<String>,
     pub birthdate: Option<NaiveDate>,
     pub sex: Sex,

--- a/mysk-lib/src/models/student/fetch_levels/default.rs
+++ b/mysk-lib/src/models/student/fetch_levels/default.rs
@@ -11,7 +11,6 @@ use crate::{
     prelude::*,
 };
 use chrono::NaiveDate;
-use mysk_lib_macros::traits::db::GetById;
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use uuid::Uuid;

--- a/mysk-lib/src/models/student/fetch_levels/detailed.rs
+++ b/mysk-lib/src/models/student/fetch_levels/detailed.rs
@@ -23,7 +23,7 @@ pub struct DetailedStudent {
     pub middle_name: Option<MultiLangString>,
     pub last_name: MultiLangString,
     pub nickname: Option<MultiLangString>,
-    pub student_id: String,
+    pub student_id: Option<String>,
     pub profile_url: Option<String>,
     pub birthdate: Option<NaiveDate>,
     pub sex: Sex,

--- a/mysk-lib/src/models/student/fetch_levels/detailed.rs
+++ b/mysk-lib/src/models/student/fetch_levels/detailed.rs
@@ -11,7 +11,6 @@ use crate::{
     prelude::*,
 };
 use chrono::NaiveDate;
-use mysk_lib_macros::traits::db::GetById;
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use uuid::Uuid;

--- a/mysk-lib/src/models/subject/db.rs
+++ b/mysk-lib/src/models/subject/db.rs
@@ -1,5 +1,7 @@
 use super::enums::subject_type::SubjectType;
-use crate::{helpers::date::get_current_academic_year, prelude::*};
+use crate::{
+    common::string::MultiLangString, helpers::date::get_current_academic_year, prelude::*,
+};
 use chrono::{DateTime, Utc};
 use mysk_lib_derives::{BaseQuery, GetById};
 use mysk_lib_macros::traits::db::{BaseQuery, GetById};
@@ -97,5 +99,25 @@ impl DbSubject {
                 "DbSubject::get_subject_co_teachers".to_string(),
             )),
         }
+    }
+
+    pub async fn get_requirements(&self, pool: &PgPool) -> Result<Vec<MultiLangString>> {
+        query!(
+            r"
+            SELECT label_th, label_en FROM subject_requirements
+            WHERE subject_id = $1
+            ",
+            self.id,
+        )
+        .fetch_all(pool)
+        .await
+        .map(|res| {
+            res.iter()
+                .map(|r| MultiLangString::new(r.label_th.clone(), r.label_en.clone()))
+                .collect::<Vec<MultiLangString>>()
+        })
+        .map_err(|e| {
+            Error::InternalSeverError(e.to_string(), "DbSubject::get_requirements".to_string())
+        })
     }
 }

--- a/mysk-lib/src/models/subject/db.rs
+++ b/mysk-lib/src/models/subject/db.rs
@@ -101,13 +101,13 @@ impl DbSubject {
         }
     }
 
-    pub async fn get_requirements(&self, pool: &PgPool) -> Result<Vec<MultiLangString>> {
+    pub async fn get_requirements(pool: &PgPool, subject_id: Uuid) -> Result<Vec<MultiLangString>> {
         query!(
             r"
             SELECT label_th, label_en FROM subject_requirements
             WHERE subject_id = $1
             ",
-            self.id,
+            subject_id,
         )
         .fetch_all(pool)
         .await

--- a/mysk-lib/src/models/teacher/fetch_levels/default.rs
+++ b/mysk-lib/src/models/teacher/fetch_levels/default.rs
@@ -13,7 +13,6 @@ use crate::{
     prelude::*,
 };
 use chrono::NaiveDate;
-use mysk_lib_macros::traits::db::GetById;
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use uuid::Uuid;

--- a/mysk-lib/src/models/teacher/fetch_levels/detailed.rs
+++ b/mysk-lib/src/models/teacher/fetch_levels/detailed.rs
@@ -13,7 +13,6 @@ use crate::{
     prelude::*,
 };
 use chrono::NaiveDate;
-use mysk_lib_macros::traits::db::GetById;
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use uuid::Uuid;


### PR DESCRIPTION
**Features**
- Limit trade offers to 3 per user at a time
  Fixes BACK-47

**Fixes**
- Cap Size can not be different for the same subject in different session

**API Changes**
- `as_student_id` is deprecated, please use the user's classroom as `applicable_classroom_ids` instead
- Electives use `id` instead of `session_code` as an identifier in all URIs

**Notes** 
For @Galax028 and @owo93 please make sure that the following tables are changed to their respective counterparts and do not come up in the codebase
- `complete_elective_subjects_view` → `elective_subject_sessions_with_detail_view`
- `elective_subject_classrooms` → `elective_subject_session_classrooms`
- `elective_subject_requirements` → `subject_requirements`
- `elective_subjects` → `elective_subject_sessions`
- `student_elective_subjects` → `elective_subject_session_enrolled_students`

@SiravitPhokeed please make sure that none of the changes break any frontend logic after fixing the API changes