### PR TITLE
[0.3.1] Quite a plethora of bug fixes

### DIFF
--- a/mysk-data-api/Cargo.toml
+++ b/mysk-data-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mysk-data-api"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/mysk-data-api/src/routes/auth/user.rs
+++ b/mysk-data-api/src/routes/auth/user.rs
@@ -3,6 +3,6 @@ use actix_web::{get, HttpResponse, Responder};
 use mysk_lib::{common::response::ResponseType, prelude::*};
 
 #[get("/user")]
-async fn get_user(user: LoggedIn, _: ApiKeyHeader) -> Result<impl Responder> {
+async fn get_user(_: ApiKeyHeader, user: LoggedIn) -> Result<impl Responder> {
     Ok(HttpResponse::Ok().json(ResponseType::new(user, None)))
 }

--- a/mysk-data-api/src/routes/v1/clubs/add_club_members.rs
+++ b/mysk-data-api/src/routes/v1/clubs/add_club_members.rs
@@ -32,12 +32,12 @@ struct AddClubMemberRequest {
 #[post("/{id}/add")]
 pub async fn add_club_members(
     data: Data<AppState>,
-    club_id: Path<Uuid>,
+    _: ApiKeyHeader,
     student_id: LoggedInStudent,
+    club_id: Path<Uuid>,
     request_body: Json<
         RequestType<AddClubMemberRequest, QueryablePlaceholder, SortablePlaceholder>,
     >,
-    _: ApiKeyHeader,
 ) -> Result<impl Responder> {
     let pool = &data.db;
     let inviter_student_id = student_id.0;

--- a/mysk-data-api/src/routes/v1/clubs/add_club_members.rs
+++ b/mysk-data-api/src/routes/v1/clubs/add_club_members.rs
@@ -44,7 +44,12 @@ pub async fn add_club_members(
     let club_id = club_id.into_inner();
     let invitee_student_id = match &request_body.data {
         Some(request_data) => request_data.id,
-        _ => unreachable!("JSON errors are pre-handled by the JsonConfig error handler"),
+        None => {
+            return Err(Error::InvalidRequest(
+                "Json deserialize error: field `data` can not be empty".to_string(),
+                format!("/clubs/{club_id}/add"),
+            ));
+        }
     };
     let fetch_level = request_body.fetch_level.as_ref();
     let descendant_fetch_level = request_body.descendant_fetch_level.as_ref();

--- a/mysk-data-api/src/routes/v1/clubs/create_club_contacts.rs
+++ b/mysk-data-api/src/routes/v1/clubs/create_club_contacts.rs
@@ -31,10 +31,10 @@ struct ClubContactRequest {
 #[post("/{id}/contacts")]
 pub async fn create_club_contacts(
     data: Data<AppState>,
-    club_id: Path<Uuid>,
-    student_id: LoggedInStudent,
-    request_body: Json<RequestType<ClubContactRequest, QueryablePlaceholder, SortablePlaceholder>>,
     _: ApiKeyHeader,
+    student_id: LoggedInStudent,
+    club_id: Path<Uuid>,
+    request_body: Json<RequestType<ClubContactRequest, QueryablePlaceholder, SortablePlaceholder>>,
 ) -> Result<impl Responder> {
     let pool = &data.db;
     let student_id = student_id.0;

--- a/mysk-data-api/src/routes/v1/clubs/create_club_contacts.rs
+++ b/mysk-data-api/src/routes/v1/clubs/create_club_contacts.rs
@@ -41,7 +41,12 @@ pub async fn create_club_contacts(
     let club_id = club_id.into_inner();
     let club_contact = match &request_body.data {
         Some(club_contact) => club_contact,
-        _ => unreachable!("JSON errors are pre-handled by the JsonConfig error handler"),
+        None => {
+            return Err(Error::InvalidRequest(
+                "Json deserialize error: field `data` can not be empty".to_string(),
+                format!("/clubs/{club_id}/contacts"),
+            ));
+        }
     };
     let fetch_level = request_body.fetch_level.as_ref();
     let descendant_fetch_level = request_body.descendant_fetch_level.as_ref();

--- a/mysk-data-api/src/routes/v1/clubs/join_clubs.rs
+++ b/mysk-data-api/src/routes/v1/clubs/join_clubs.rs
@@ -31,10 +31,10 @@ use uuid::Uuid;
 #[post("/{id}/join")]
 pub async fn join_clubs(
     data: Data<AppState>,
-    club_id: Path<Uuid>,
-    student_id: LoggedInStudent,
-    request_body: RequestType<ClubRequest, QueryableClubRequest, SortableClubRequest>,
     _: ApiKeyHeader,
+    student_id: LoggedInStudent,
+    club_id: Path<Uuid>,
+    request_body: RequestType<ClubRequest, QueryableClubRequest, SortableClubRequest>,
 ) -> Result<impl Responder> {
     let pool = &data.db;
     let student_id = student_id.0;

--- a/mysk-data-api/src/routes/v1/clubs/query_club_details.rs
+++ b/mysk-data-api/src/routes/v1/clubs/query_club_details.rs
@@ -17,9 +17,9 @@ use uuid::Uuid;
 #[get("/{id}")]
 pub async fn query_club_details(
     data: Data<AppState>,
+    _: ApiKeyHeader,
     club_id: Path<Uuid>,
     request_query: RequestType<Club, QueryablePlaceholder, SortablePlaceholder>,
-    _: ApiKeyHeader,
 ) -> Result<impl Responder> {
     let pool = &data.db;
     let club_id = club_id.into_inner();

--- a/mysk-data-api/src/routes/v1/clubs/query_clubs.rs
+++ b/mysk-data-api/src/routes/v1/clubs/query_clubs.rs
@@ -18,8 +18,8 @@ use mysk_lib::{
 #[get("")]
 pub async fn query_clubs(
     data: Data<AppState>,
-    request_query: RequestType<Club, QueryableClub, SortableClub>,
     _: ApiKeyHeader,
+    request_query: RequestType<Club, QueryableClub, SortableClub>,
 ) -> Result<impl Responder> {
     let pool = &data.db;
     let fetch_level = request_query.fetch_level.as_ref();

--- a/mysk-data-api/src/routes/v1/clubs/requests/delete_club_requests.rs
+++ b/mysk-data-api/src/routes/v1/clubs/requests/delete_club_requests.rs
@@ -24,9 +24,9 @@ use uuid::Uuid;
 #[delete("/{id}")]
 pub async fn delete_club_requests(
     data: Data<AppState>,
+    _: ApiKeyHeader,
     club_request_id: Path<Uuid>,
     student_id: LoggedInStudent,
-    _: ApiKeyHeader,
 ) -> Result<impl Responder> {
     let pool = &data.db;
     let student_id = student_id.0;

--- a/mysk-data-api/src/routes/v1/clubs/requests/query_club_request_details.rs
+++ b/mysk-data-api/src/routes/v1/clubs/requests/query_club_request_details.rs
@@ -17,9 +17,9 @@ use uuid::Uuid;
 #[get("/{id}")]
 pub async fn query_club_request_details(
     data: Data<AppState>,
+    _: ApiKeyHeader,
     club_id: Path<Uuid>,
     request_query: RequestType<ClubRequest, QueryablePlaceholder, SortablePlaceholder>,
-    _: ApiKeyHeader,
 ) -> Result<impl Responder> {
     let pool = &data.db;
     let club_id = club_id.into_inner();

--- a/mysk-data-api/src/routes/v1/clubs/requests/query_club_requests.rs
+++ b/mysk-data-api/src/routes/v1/clubs/requests/query_club_requests.rs
@@ -18,8 +18,8 @@ use mysk_lib::{
 #[get("")]
 pub async fn query_club_requests(
     data: Data<AppState>,
-    request_query: RequestType<ClubRequest, QueryableClubRequest, SortableClubRequest>,
     _: ApiKeyHeader,
+    request_query: RequestType<ClubRequest, QueryableClubRequest, SortableClubRequest>,
 ) -> Result<impl Responder> {
     let pool = &data.db;
     let fetch_level = request_query.fetch_level.as_ref();

--- a/mysk-data-api/src/routes/v1/clubs/requests/update_club_requests.rs
+++ b/mysk-data-api/src/routes/v1/clubs/requests/update_club_requests.rs
@@ -32,10 +32,10 @@ struct UpdateClubRequest {
 #[put("/{id}")]
 pub async fn update_club_requests(
     data: Data<AppState>,
+    _: ApiKeyHeader,
+    student_id: LoggedInStudent,
     club_request_id: Path<Uuid>,
     request_body: Json<RequestType<UpdateClubRequest, QueryablePlaceholder, SortablePlaceholder>>,
-    student_id: LoggedInStudent,
-    _: ApiKeyHeader,
 ) -> Result<impl Responder> {
     let pool = &data.db;
     let student_id = student_id.0;
@@ -50,7 +50,12 @@ pub async fn update_club_requests(
                 ));
             }
         },
-        _ => unreachable!("JSON errors are pre-handled by the JsonConfig error handler"),
+        None => {
+            return Err(Error::InvalidRequest(
+                "Json deserialize error: field `data` can not be empty".to_string(),
+                format!("/clubs/requests/{club_request_id}"),
+            ));
+        }
     };
     let fetch_level = request_body.fetch_level.as_ref();
     let descendant_fetch_level = request_body.descendant_fetch_level.as_ref();

--- a/mysk-data-api/src/routes/v1/students/get_student_by_id.rs
+++ b/mysk-data-api/src/routes/v1/students/get_student_by_id.rs
@@ -17,9 +17,9 @@ use uuid::Uuid;
 #[get("/{id}")]
 pub async fn get_student_by_id(
     data: Data<AppState>,
+    _: ApiKeyHeader,
     id: Path<Uuid>,
     request_query: RequestType<Student, QueryablePlaceholder, SortablePlaceholder>,
-    _: ApiKeyHeader,
 ) -> Result<impl Responder> {
     let pool = &data.db;
     let student_id = id.into_inner();

--- a/mysk-data-api/src/routes/v1/subjects/electives/in_enrollment_period.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/in_enrollment_period.rs
@@ -9,6 +9,7 @@ pub async fn in_enrollment_period(data: Data<AppState>, _: ApiKeyHeader) -> Resu
     let pool = &data.db;
 
     let is_in_enrollment_period = DbElectiveSubject::is_enrollment_period(pool).await?;
+    let response = ResponseType::new(is_in_enrollment_period, None);
 
-    Ok(HttpResponse::Ok().json(ResponseType::new(is_in_enrollment_period, None)))
+    Ok(HttpResponse::Ok().json(response))
 }

--- a/mysk-data-api/src/routes/v1/subjects/electives/modify_electives.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/modify_electives.rs
@@ -27,14 +27,14 @@ use uuid::Uuid;
 #[put("/{id}/enroll")]
 async fn modify_elective_subject(
     data: Data<AppState>,
-    id: Path<Uuid>,
-    student_id: LoggedInStudent,
-    request_body: Json<RequestType<ElectiveSubject, QueryablePlaceholder, SortablePlaceholder>>,
     _: ApiKeyHeader,
+    student_id: LoggedInStudent,
+    elective_subject_session_id: Path<Uuid>,
+    request_body: Json<RequestType<ElectiveSubject, QueryablePlaceholder, SortablePlaceholder>>,
 ) -> Result<impl Responder> {
     let pool = &data.db;
     let student_id = student_id.0;
-    let elective_subject_session_id = id.into_inner();
+    let elective_subject_session_id = elective_subject_session_id.into_inner();
     let fetch_level = request_body.fetch_level.as_ref();
     let descendant_fetch_level = request_body.descendant_fetch_level.as_ref();
 

--- a/mysk-data-api/src/routes/v1/subjects/electives/query_elective_details.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/query_elective_details.rs
@@ -17,9 +17,9 @@ use uuid::Uuid;
 #[get("/{id}")]
 pub async fn query_elective_details(
     data: Data<AppState>,
+    _: ApiKeyHeader,
     elective_subject_session_id: Path<Uuid>,
     request_query: RequestType<ElectiveSubject, QueryablePlaceholder, SortablePlaceholder>,
-    _: ApiKeyHeader,
 ) -> Result<impl Responder> {
     let pool = &data.db;
     let elective_subject_session_id = elective_subject_session_id.into_inner();

--- a/mysk-data-api/src/routes/v1/subjects/electives/query_electives.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/query_electives.rs
@@ -18,8 +18,8 @@ use mysk_lib::{
 #[get("")]
 pub async fn query_elective_subject(
     data: Data<AppState>,
-    request_query: RequestType<ElectiveSubject, QueryableElectiveSubject, SortableElectiveSubject>,
     _: ApiKeyHeader,
+    request_query: RequestType<ElectiveSubject, QueryableElectiveSubject, SortableElectiveSubject>,
 ) -> Result<impl Responder> {
     let pool = &data.db;
     let fetch_level = request_query.fetch_level.as_ref();

--- a/mysk-data-api/src/routes/v1/subjects/electives/trade_offers/create_offer.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/trade_offers/create_offer.rs
@@ -34,11 +34,11 @@ struct ElectiveTradeOfferRequest {
 #[post("")]
 async fn create_trade_offer(
     data: Data<AppState>,
+    _: ApiKeyHeader,
+    student_id: LoggedInStudent,
     request_body: Json<
         RequestType<ElectiveTradeOfferRequest, QueryablePlaceholder, SortablePlaceholder>,
     >,
-    student_id: LoggedInStudent,
-    _: ApiKeyHeader,
 ) -> Result<impl Responder> {
     let pool = &data.db;
     let receiver_student_id = match &request_body.data {

--- a/mysk-data-api/src/routes/v1/subjects/electives/trade_offers/create_offer.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/trade_offers/create_offer.rs
@@ -43,7 +43,12 @@ async fn create_trade_offer(
     let pool = &data.db;
     let receiver_student_id = match &request_body.data {
         Some(request_data) => request_data.receiver_id,
-        _ => unreachable!("JSON errors are pre-handled by the JsonConfig error handler"),
+        None => {
+            return Err(Error::InvalidRequest(
+                "Json deserialize error: field `data` can not be empty".to_string(),
+                format!("/subjects/electives/trade-offers"),
+            ));
+        }
     };
     let sender_student_id = student_id.0;
     let fetch_level = request_body.fetch_level.as_ref();

--- a/mysk-data-api/src/routes/v1/subjects/electives/trade_offers/query_offers.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/trade_offers/query_offers.rs
@@ -20,12 +20,12 @@ use mysk_lib::{
 #[get("")]
 pub async fn query_trade_offers(
     data: Data<AppState>,
+    _: ApiKeyHeader,
     request_body: RequestType<
         ElectiveTradeOffer,
         QueryableElectiveTradeOffer,
         SortableElectiveTradeOffer,
     >,
-    _: ApiKeyHeader,
 ) -> Result<impl Responder> {
     let pool = &data.db;
     let fetch_level = request_body.fetch_level.as_ref();

--- a/mysk-data-api/src/routes/v1/subjects/electives/trade_offers/update_offer.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/trade_offers/update_offer.rs
@@ -33,12 +33,12 @@ struct UpdatableElectiveOffer {
 #[put("/{id}")]
 async fn update_trade_offer(
     data: Data<AppState>,
+    _: ApiKeyHeader,
+    student_id: LoggedInStudent,
     trade_offer_id: Path<Uuid>,
     request_body: Json<
         RequestType<UpdatableElectiveOffer, QueryablePlaceholder, SortablePlaceholder>,
     >,
-    student_id: LoggedInStudent,
-    _: ApiKeyHeader,
 ) -> Result<impl Responder> {
     let pool = &data.db;
     let client_student_id = student_id.0;

--- a/mysk-data-api/src/routes/v1/subjects/electives/trade_offers/update_offer.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/trade_offers/update_offer.rs
@@ -53,7 +53,12 @@ async fn update_trade_offer(
                 ));
             }
         },
-        _ => unreachable!("JSON errors are pre-handled by the JsonConfig error handler"),
+        None => {
+            return Err(Error::InvalidRequest(
+                "Json deserialize error: field `data` can not be empty".to_string(),
+                format!("/subjects/electives/trade-offers/{trade_offer_id}"),
+            ));
+        }
     };
     let fetch_level = request_body.fetch_level.as_ref();
     let descendant_fetch_level = request_body.descendant_fetch_level.as_ref();

--- a/mysk-data-api/src/routes/v1/teachers/get_teacher_by_id.rs
+++ b/mysk-data-api/src/routes/v1/teachers/get_teacher_by_id.rs
@@ -17,11 +17,11 @@ use uuid::Uuid;
 #[get("/{id}")]
 pub async fn get_teacher_by_id(
     data: Data<AppState>,
+    _: ApiKeyHeader,
     id: Path<Uuid>,
     request_query: RequestType<Teacher, QueryablePlaceholder, SortablePlaceholder>,
-    _: ApiKeyHeader,
 ) -> Result<impl Responder> {
-    let pool: &sqlx::Pool<sqlx::Postgres> = &data.db;
+    let pool = &data.db;
     let teacher_id = id.into_inner();
     let fetch_level = request_query.fetch_level.as_ref();
     let descendant_fetch_level = request_query.descendant_fetch_level.as_ref();

--- a/mysk-lib-derives/Cargo.toml
+++ b/mysk-lib-derives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mysk-lib-derives"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/mysk-lib-macros/Cargo.toml
+++ b/mysk-lib-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mysk-lib-macros"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/mysk-lib/Cargo.toml
+++ b/mysk-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mysk-lib"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/mysk-lib/src/auth/oauth.rs
+++ b/mysk-lib/src/auth/oauth.rs
@@ -92,7 +92,7 @@ struct GoogleOAuthInitQueryParams {
     state: String,
     include_granted_scopes: bool,
     hd: String,
-    prompt: String,
+    prompt: Option<String>,
 }
 
 pub fn generate_oauth_init_url(client_id: &str, redirect_uri: &str) -> (String, String) {
@@ -115,9 +115,7 @@ pub fn generate_oauth_init_url(client_id: &str, redirect_uri: &str) -> (String, 
         include_granted_scopes: true,
         hd: "sk.ac.th".to_string(),
         #[cfg(debug_assertions)]
-        prompt: "select_account".to_string(),
-        #[cfg(not(debug_assertions))]
-        prompt: "none".to_string(),
+        prompt: Some("select_account".to_string()),
     };
 
     (

--- a/mysk-lib/src/auth/oauth.rs
+++ b/mysk-lib/src/auth/oauth.rs
@@ -116,6 +116,8 @@ pub fn generate_oauth_init_url(client_id: &str, redirect_uri: &str) -> (String, 
         hd: "sk.ac.th".to_string(),
         #[cfg(debug_assertions)]
         prompt: Some("select_account".to_string()),
+        #[cfg(not(debug_assertions))]
+        prompt: None,
     };
 
     (

--- a/mysk-lib/src/common/requests.rs
+++ b/mysk-lib/src/common/requests.rs
@@ -93,15 +93,22 @@ impl PaginationConfig {
         Self { p, size }
     }
 
-    pub fn to_limit_clause(&self) -> SqlSection {
+    pub fn to_limit_clause(&self) -> Result<SqlSection> {
+        if self.p == 0 {
+            return Err(Error::InvalidRequest(
+                "Page number must be greater than zero".to_string(),
+                "PaginationConfig::to_limit_clause".to_string(),
+            ));
+        }
+
         // LIMIT $1 OFFSET $2
-        SqlSection {
+        Ok(SqlSection {
             sql: vec!["LIMIT ".to_string(), " OFFSET ".to_string()],
             params: vec![
                 QueryParam::Int(i64::from(self.size.unwrap_or(50))),
                 QueryParam::Int(i64::from((self.p - 1) * self.size.unwrap_or(50))),
             ],
-        }
+        })
     }
 }
 

--- a/mysk-lib/src/error.rs
+++ b/mysk-lib/src/error.rs
@@ -24,6 +24,8 @@ pub enum Error {
 
     // Auth errors
     /// HTTP 401 - [Unauthorized](https://developer.mozilla.org/docs/Web/HTTP/Status/401)
+    InvalidAuthorizationScheme(String, String),
+    /// HTTP 401 - [Unauthorized](https://developer.mozilla.org/docs/Web/HTTP/Status/401)
     InvalidToken(String, String),
     /// HTTP 401 - [Unauthorized](https://developer.mozilla.org/docs/Web/HTTP/Status/401)
     MissingToken(String, String),
@@ -68,6 +70,13 @@ impl From<&Error> for ErrorType {
                 id: Uuid::new_v4(),
                 code: 500,
                 error_type: "internal_server_error".to_string(),
+                detail: detail.to_string(),
+                source: source.to_string(),
+            },
+            Error::InvalidAuthorizationScheme(detail, source) => ErrorType {
+                id: Uuid::new_v4(),
+                code: 401,
+                error_type: "invalid_authorization_scheme".to_string(),
                 detail: detail.to_string(),
                 source: source.to_string(),
             },
@@ -118,7 +127,8 @@ impl From<&Error> for HttpResponse {
             Error::InvalidPermission(_, _) => HttpResponse::Forbidden().json(res_val),
             Error::Conflicted(_, _) => HttpResponse::Conflict().json(res_val),
             Error::InternalSeverError(_, _) => HttpResponse::InternalServerError().json(res_val),
-            Error::InvalidToken(_, _)
+            Error::InvalidAuthorizationScheme(_, _)
+            | Error::InvalidToken(_, _)
             | Error::MissingToken(_, _)
             | Error::MissingApiKey(_, _)
             | Error::InvalidApiKey(_, _) => HttpResponse::Unauthorized().json(res_val),
@@ -173,6 +183,9 @@ impl Display for Error {
             }
             Error::InternalSeverError(detail, source) => {
                 format!("Internal server error: {detail} (source: {source})")
+            }
+            Error::InvalidAuthorizationScheme(detail, source) => {
+                format!("Invalid authorization scheme: {detail} (source: {source})")
             }
             Error::InvalidToken(detail, source) => {
                 format!("Invalid token: {detail} (source: {source})")

--- a/mysk-lib/src/models/club/db.rs
+++ b/mysk-lib/src/models/club/db.rs
@@ -166,7 +166,7 @@ impl QueryDb<QueryableClub, SortableClub> for DbClub {
         }
 
         if let Some(pagination) = pagination {
-            let limit_section = pagination.to_limit_clause();
+            let limit_section = pagination.to_limit_clause()?;
             query.push(" ");
             for (i, sql) in limit_section.sql.iter().enumerate() {
                 query.push(sql);

--- a/mysk-lib/src/models/club_request/db.rs
+++ b/mysk-lib/src/models/club_request/db.rs
@@ -81,7 +81,7 @@ impl QueryDb<QueryableClubRequest, SortableClubRequest> for DbClubRequest {
         }
 
         if let Some(pagination) = pagination {
-            let limit_section = pagination.to_limit_clause();
+            let limit_section = pagination.to_limit_clause()?;
             query.push(" ");
             for (i, sql) in limit_section.sql.iter().enumerate() {
                 query.push(sql);

--- a/mysk-lib/src/models/elective_subject/db.rs
+++ b/mysk-lib/src/models/elective_subject/db.rs
@@ -243,7 +243,7 @@ impl QueryDb<QueryableElectiveSubject, SortableElectiveSubject> for DbElectiveSu
         }
 
         if let Some(pagination) = pagination {
-            let limit_section = pagination.to_limit_clause();
+            let limit_section = pagination.to_limit_clause()?;
             query.push(" ");
             for (i, sql) in limit_section.sql.iter().enumerate() {
                 query.push(sql);

--- a/mysk-lib/src/models/elective_trade_offer/db.rs
+++ b/mysk-lib/src/models/elective_trade_offer/db.rs
@@ -82,7 +82,7 @@ impl QueryDb<QueryableElectiveTradeOffer, SortableElectiveTradeOffer> for DbElec
         }
 
         if let Some(pagination) = pagination {
-            let limit_section = pagination.to_limit_clause();
+            let limit_section = pagination.to_limit_clause()?;
             query.push(" ");
             for (i, sql) in limit_section.sql.iter().enumerate() {
                 query.push(sql);

--- a/mysk-lib/src/models/top_level_variant.rs
+++ b/mysk-lib/src/models/top_level_variant.rs
@@ -129,7 +129,7 @@ where
                         "TopLevelGetById::get_by_id".to_string(),
                     ),
                     _ => Error::InternalSeverError(
-                        "An unknown database error had occurred".to_string(),
+                        "Internal server error".to_string(),
                         "TopLevelGetById::get_by_id".to_string(),
                     ),
                 });
@@ -158,7 +158,7 @@ where
                         "TopLevelGetById::get_by_ids".to_string(),
                     ),
                     _ => Error::InternalSeverError(
-                        "An unknown database error had occurred".to_string(),
+                        "Internal server error".to_string(),
                         "TopLevelGetById::get_by_ids".to_string(),
                     ),
                 });


### PR DESCRIPTION
I'm making this a draft for now, in case someone else spots some other bugs/errors that I might not have thought of.

## Fixes

- Using zero as the page number for pagination in requests no longer results in an unexpected panic (BACK-79).
- The Google OAuth flow shows a consent/account chooser screen when being called in a production environment.
- The `LoggedIn` extractor now properly checks the authorization scheme (`Bearer`).
- Extractors have now been reordered to help with error-precedence (`AppState > ApiKey > LoggedIn > LoggedInStudent > Path/Json`).
- Setting the `body` field as `null` in endpoints that require a JSON body now does not throw a `502 Gateway Timeout` (BACK-80).
- Sending an erroneous API key or other gibberish now does not throw a `502 Gateway Timeout` (BACK-80).