### PR TITLE
[0.3.2] Club Statistics

### DIFF
--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -1,6 +1,6 @@
 procs:
   mysk-api-server:
-    shell: "cargo run"
+    shell: "cargo run -q"
     autorestart: true
 
   test-web-server:

--- a/mysk-data-api/Cargo.toml
+++ b/mysk-data-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mysk-data-api"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/mysk-data-api/src/routes/v1/clubs/get_club_statistics.rs
+++ b/mysk-data-api/src/routes/v1/clubs/get_club_statistics.rs
@@ -20,7 +20,7 @@ impl ClubStatistics {
 
         let club_members = query!(
             "SELECT COUNT(DISTINCT student_id) as count FROM club_members WHERE year = $1",
-            current_year
+            current_year,
         )
         .fetch_one(pool)
         .await?
@@ -29,7 +29,7 @@ impl ClubStatistics {
 
         let club_staffs = query!(
             "SELECT COUNT(DISTINCT student_id) as count FROM club_staffs WHERE year = $1",
-            current_year
+            current_year,
         )
         .fetch_one(pool)
         .await?
@@ -38,7 +38,7 @@ impl ClubStatistics {
 
         let active_clubs = query!(
             "SELECT COUNT(DISTINCT club_id) as count FROM club_staffs WHERE year = $1",
-            current_year
+            current_year,
         )
         .fetch_one(pool)
         .await?
@@ -47,7 +47,11 @@ impl ClubStatistics {
 
         // Total students for percentage calculation
         let total_students = query!(
-            "SELECT count(DISTINCT students.id) as count FROM students JOIN classroom_students  ON classroom_students.student_id = students.id JOIN classrooms  ON classrooms.id = classroom_students.classroom_id AND classrooms.year = $1", current_year
+            "SELECT count(DISTINCT students.id) as count FROM students
+            JOIN classroom_students ON classroom_students.student_id = students.id
+            JOIN classrooms ON classrooms.id = classroom_students.classroom_id
+            AND classrooms.year = $1",
+            current_year,
         )
         .fetch_one(pool)
         .await?

--- a/mysk-data-api/src/routes/v1/clubs/get_club_statistics.rs
+++ b/mysk-data-api/src/routes/v1/clubs/get_club_statistics.rs
@@ -1,4 +1,4 @@
-use crate::{extractors::api_key::ApiKeyHeader, AppState};
+use crate::AppState;
 use actix_web::{get, web::Data, HttpResponse, Responder};
 use mysk_lib::{
     common::response::ResponseType, helpers::date::get_current_academic_year, prelude::*,

--- a/mysk-data-api/src/routes/v1/clubs/get_club_statistics.rs
+++ b/mysk-data-api/src/routes/v1/clubs/get_club_statistics.rs
@@ -37,7 +37,7 @@ impl ClubStatistics {
         .unwrap_or(0);
 
         let active_clubs = query!(
-            "SELECT COUNT(DISTINCT club_id) as count FROM club_staffs JOIN clubs ON club_staffs.club_id = clubs.id WHERE club_staffs.year = $1",
+            "SELECT COUNT(DISTINCT club_id) as count FROM club_staffs WHERE year = $1",
             current_year
         )
         .fetch_one(pool)

--- a/mysk-data-api/src/routes/v1/clubs/get_club_statistics.rs
+++ b/mysk-data-api/src/routes/v1/clubs/get_club_statistics.rs
@@ -1,0 +1,73 @@
+use crate::{extractors::api_key::ApiKeyHeader, AppState};
+use actix_web::{get, web::Data, HttpResponse, Responder};
+use mysk_lib::{
+    common::response::ResponseType, helpers::date::get_current_academic_year, prelude::*,
+};
+use serde::Serialize;
+use sqlx::{query, PgPool};
+
+#[derive(Debug, Serialize)]
+struct ClubStatistics {
+    pub new_club_members: i64,
+    pub new_club_staffs: i64,
+    pub active_clubs: i64,
+    pub total_students: i64,
+}
+
+impl ClubStatistics {
+    pub async fn new(pool: &PgPool) -> Result<Self> {
+        let current_year = get_current_academic_year(None);
+
+        let new_club_members = query!(
+            "SELECT COUNT(DISTINCT student_id) as count FROM club_members WHERE year = $1",
+            current_year
+        )
+        .fetch_one(pool)
+        .await?
+        .count
+        .unwrap_or(0);
+
+        let new_club_staffs = query!(
+            "SELECT COUNT(DISTINCT student_id) as count FROM club_staffs WHERE year = $1",
+            current_year
+        )
+        .fetch_one(pool)
+        .await?
+        .count
+        .unwrap_or(0);
+
+        let active_clubs = query!(
+            "SELECT COUNT(DISTINCT club_id) as count FROM club_staffs JOIN clubs ON club_staffs.club_id = clubs.id WHERE club_staffs.year = $1",
+            current_year
+        )
+        .fetch_one(pool)
+        .await?
+        .count
+        .unwrap_or(0);
+
+        // Total students for percentage calculation
+        let total_students = query!(
+            "SELECT count(DISTINCT students.id) as count FROM students JOIN classroom_students  ON classroom_students.student_id = students.id JOIN classrooms  ON classrooms.id = classroom_students.classroom_id AND classrooms.year = $1", current_year
+        )
+        .fetch_one(pool)
+        .await?
+        .count
+        .unwrap_or(0);
+
+        Ok(ClubStatistics {
+            new_club_members,
+            new_club_staffs,
+            active_clubs,
+            total_students,
+        })
+    }
+}
+
+#[get("/statistics")]
+async fn get_club_statistics(data: Data<AppState>) -> Result<impl Responder> {
+    let pool = &data.db;
+    let statistics = ClubStatistics::new(pool).await?;
+    let response = ResponseType::new(statistics, None);
+
+    Ok(HttpResponse::Ok().json(response))
+}

--- a/mysk-data-api/src/routes/v1/clubs/get_club_statistics.rs
+++ b/mysk-data-api/src/routes/v1/clubs/get_club_statistics.rs
@@ -1,4 +1,4 @@
-use crate::AppState;
+use crate::{extractors::api_key::ApiKeyHeader, AppState};
 use actix_web::{get, web::Data, HttpResponse, Responder};
 use mysk_lib::{
     common::response::ResponseType, helpers::date::get_current_academic_year, prelude::*,
@@ -68,7 +68,7 @@ impl ClubStatistics {
 }
 
 #[get("/statistics")]
-async fn get_club_statistics(data: Data<AppState>) -> Result<impl Responder> {
+async fn get_club_statistics(data: Data<AppState>, _: ApiKeyHeader) -> Result<impl Responder> {
     let pool = &data.db;
     let statistics = ClubStatistics::new(pool).await?;
     let response = ResponseType::new(statistics, None);

--- a/mysk-data-api/src/routes/v1/clubs/get_club_statistics.rs
+++ b/mysk-data-api/src/routes/v1/clubs/get_club_statistics.rs
@@ -8,8 +8,8 @@ use sqlx::{query, PgPool};
 
 #[derive(Debug, Serialize)]
 struct ClubStatistics {
-    pub new_club_members: i64,
-    pub new_club_staffs: i64,
+    pub club_members: i64,
+    pub club_staffs: i64,
     pub active_clubs: i64,
     pub total_students: i64,
 }
@@ -18,7 +18,7 @@ impl ClubStatistics {
     pub async fn new(pool: &PgPool) -> Result<Self> {
         let current_year = get_current_academic_year(None);
 
-        let new_club_members = query!(
+        let club_members = query!(
             "SELECT COUNT(DISTINCT student_id) as count FROM club_members WHERE year = $1",
             current_year
         )
@@ -27,7 +27,7 @@ impl ClubStatistics {
         .count
         .unwrap_or(0);
 
-        let new_club_staffs = query!(
+        let club_staffs = query!(
             "SELECT COUNT(DISTINCT student_id) as count FROM club_staffs WHERE year = $1",
             current_year
         )
@@ -55,8 +55,8 @@ impl ClubStatistics {
         .unwrap_or(0);
 
         Ok(ClubStatistics {
-            new_club_members,
-            new_club_staffs,
+            club_members,
+            club_staffs,
             active_clubs,
             total_students,
         })

--- a/mysk-data-api/src/routes/v1/clubs/mod.rs
+++ b/mysk-data-api/src/routes/v1/clubs/mod.rs
@@ -2,6 +2,7 @@ use actix_web::web::{scope, ServiceConfig};
 
 pub mod add_club_members;
 pub mod create_club_contacts;
+pub mod get_club_statistics;
 pub mod join_clubs;
 pub mod query_club_details;
 pub mod query_clubs;
@@ -9,6 +10,7 @@ pub mod requests;
 
 pub fn config(cfg: &mut ServiceConfig) {
     cfg.service(scope("/requests").configure(requests::config));
+    cfg.service(get_club_statistics::get_club_statistics);
     cfg.service(add_club_members::add_club_members);
     cfg.service(join_clubs::join_clubs);
     cfg.service(create_club_contacts::create_club_contacts);

--- a/mysk-lib-derives/Cargo.toml
+++ b/mysk-lib-derives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mysk-lib-derives"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/mysk-lib-macros/Cargo.toml
+++ b/mysk-lib-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mysk-lib-macros"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/mysk-lib/Cargo.toml
+++ b/mysk-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mysk-lib"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
![image](https://github.com/suankularb-wittayalai-school/mysk-api/assets/81215142/306d4605-1697-40dc-ac0c-9aeb1c7bbe9b)

**Features**
GET /v1/clubs/statistics [BACK-83](https://linear.app/skiso/issue/BACK-83/)
  - Total number of new club members
  - Total number of new club staffs
  - Total number of active clubs (measured by staff presence in 2024)
  - Total number of students in 2024 (for calculating %)
  
> [!TIP]
> Total participation is calculated from the sum of new members and new staff
  

**Fixes**
- `mprocs` now runs `cargo run -q` for quieter logging