### PR TITLE
[0.5.0] Contact Endpoints

### DIFF
--- a/mysk-data-api/src/routes/v1/contacts/delete_contacts.rs
+++ b/mysk-data-api/src/routes/v1/contacts/delete_contacts.rs
@@ -1,0 +1,69 @@
+use crate::{
+    extractors::{api_key::ApiKeyHeader, logged_in::LoggedIn},
+    AppState,
+};
+use actix_web::{
+    delete,
+    web::{Data, Json},
+    HttpResponse, Responder,
+};
+use mysk_lib::{
+    common::{
+        requests::{QueryablePlaceholder, RequestType, SortablePlaceholder},
+        response::{EmptyResponseData, ResponseType},
+    },
+    models::contact::db::DbContact,
+    permissions::{self, ActionType},
+    prelude::*,
+};
+use mysk_lib_macros::traits::db::GetById as _;
+use sqlx::query;
+use std::sync::Arc;
+use uuid::Uuid;
+
+#[delete("")]
+pub async fn delete_contacts(
+    data: Data<AppState>,
+    _: ApiKeyHeader,
+    user: LoggedIn,
+    request_body: Json<RequestType<Vec<Uuid>, QueryablePlaceholder, SortablePlaceholder>>,
+) -> Result<impl Responder> {
+    let pool = &data.db;
+    let user = user.0;
+    let Some(contact_ids) = &request_body.data else {
+        return Err(Error::InvalidRequest(
+            "Json deserialize error: field `data` can not be empty".to_string(),
+            "/contacts".to_string(),
+        ));
+    };
+    let authorizer = permissions::get_authorizer(pool, &user, "/contacts".to_string()).await?;
+
+    // Check if the contacts exists
+    let db_contacts = DbContact::get_by_ids(pool, contact_ids.clone()).await?;
+
+    let authorizer = Arc::new(authorizer);
+    let futures: Vec<_> = db_contacts
+        .into_iter()
+        .map(|db_contact| {
+            let pool = pool.clone();
+            let authorizer = authorizer.clone();
+
+            tokio::spawn(async move {
+                authorizer
+                    .authorize_contact(&db_contact, &pool, ActionType::Delete)
+                    .await
+            })
+        })
+        .collect();
+    for future in futures {
+        future.await??;
+    }
+
+    query!("DELETE FROM contacts WHERE id = ANY($1)", contact_ids)
+        .execute(pool)
+        .await?;
+
+    let response = ResponseType::new(EmptyResponseData {}, None);
+
+    Ok(HttpResponse::Ok().json(response))
+}

--- a/mysk-data-api/src/routes/v1/contacts/mod.rs
+++ b/mysk-data-api/src/routes/v1/contacts/mod.rs
@@ -1,0 +1,13 @@
+use actix_web::web::ServiceConfig;
+
+pub mod delete_contacts;
+pub mod modify_contacts;
+pub mod query_contact_details;
+pub mod query_contacts;
+
+pub fn config(cfg: &mut ServiceConfig) {
+    cfg.service(delete_contacts::delete_contacts);
+    cfg.service(modify_contacts::modify_contacts);
+    cfg.service(query_contact_details::query_contact_details);
+    cfg.service(query_contacts::query_contacts);
+}

--- a/mysk-data-api/src/routes/v1/contacts/modify_contacts.rs
+++ b/mysk-data-api/src/routes/v1/contacts/modify_contacts.rs
@@ -1,0 +1,112 @@
+use crate::{
+    extractors::{api_key::ApiKeyHeader, logged_in::LoggedIn},
+    AppState,
+};
+use actix_web::{
+    put,
+    web::{Data, Json, Path},
+    HttpResponse, Responder,
+};
+use mysk_lib::{
+    common::{
+        requests::{QueryablePlaceholder, RequestType, SortablePlaceholder},
+        response::ResponseType,
+        string::FlexibleMultiLangString,
+    },
+    models::{
+        contact::{db::DbContact, Contact},
+        enums::ContactType,
+        traits::TopLevelGetById as _,
+    },
+    permissions::{self, ActionType},
+    prelude::*,
+};
+use mysk_lib_macros::traits::db::GetById;
+use serde::Deserialize;
+use sqlx::query;
+use uuid::Uuid;
+
+#[derive(Debug, Deserialize)]
+struct ModifyContactsRequest {
+    pub name: Option<FlexibleMultiLangString>,
+    pub r#type: Option<ContactType>,
+    pub value: Option<String>,
+    pub include_students: Option<bool>,
+    pub include_teachers: Option<bool>,
+    pub include_parents: Option<bool>,
+}
+
+#[put("/{id}")]
+pub async fn modify_contacts(
+    data: Data<AppState>,
+    _: ApiKeyHeader,
+    user: LoggedIn,
+    contact_id: Path<Uuid>,
+    request_body: Json<
+        RequestType<ModifyContactsRequest, QueryablePlaceholder, SortablePlaceholder>,
+    >,
+) -> Result<impl Responder> {
+    let pool = &data.db;
+    let user = user.0;
+    let contact_id = contact_id.into_inner();
+    let Some(contact) = &request_body.data else {
+        return Err(Error::InvalidRequest(
+            "Json deserialize error: field `data` can not be empty".to_string(),
+            format!("/contacts/{contact_id}"),
+        ));
+    };
+    let fetch_level = request_body.fetch_level.as_ref();
+    let descendant_fetch_level = request_body.descendant_fetch_level.as_ref();
+    let authorizer =
+        permissions::get_authorizer(pool, &user, format!("/contacts/{contact_id}")).await?;
+
+    // Check if the contact exists
+    let db_contact = DbContact::get_by_id(pool, contact_id).await?;
+
+    authorizer
+        .authorize_contact(&db_contact, pool, ActionType::Update)
+        .await?;
+    query!(
+        "
+        UPDATE contacts SET
+            name_en = COALESCE($1, name_en),
+            name_th = COALESCE($2, name_th),
+            type = COALESCE($3, type),
+            value = COALESCE($4, value),
+            include_students = COALESCE($5, include_students),
+            include_teachers = COALESCE($6, include_teachers),
+            include_parents  = COALESCE($7, include_parents)
+        WHERE id = $8
+        ",
+        if contact.name.is_some() {
+            contact.name.clone().unwrap().en
+        } else {
+            None
+        },
+        if contact.name.is_some() {
+            contact.name.clone().unwrap().th
+        } else {
+            None
+        },
+        contact.r#type as Option<ContactType>,
+        contact.value,
+        contact.include_students,
+        contact.include_teachers,
+        contact.include_parents,
+        contact_id,
+    )
+    .execute(pool)
+    .await?;
+
+    let updated_contact = Contact::get_by_id(
+        pool,
+        contact_id,
+        fetch_level,
+        descendant_fetch_level,
+        &authorizer,
+    )
+    .await?;
+    let response = ResponseType::new(updated_contact, None);
+
+    Ok(HttpResponse::Ok().json(response))
+}

--- a/mysk-data-api/src/routes/v1/contacts/query_contact_details.rs
+++ b/mysk-data-api/src/routes/v1/contacts/query_contact_details.rs
@@ -1,0 +1,48 @@
+use crate::{
+    extractors::{api_key::ApiKeyHeader, logged_in::LoggedIn},
+    AppState,
+};
+use actix_web::{
+    get,
+    web::{Data, Path},
+    HttpResponse, Responder,
+};
+use mysk_lib::{
+    common::{
+        requests::{QueryablePlaceholder, RequestType, SortablePlaceholder},
+        response::ResponseType,
+    },
+    models::{contact::Contact, traits::TopLevelGetById as _},
+    permissions,
+    prelude::*,
+};
+use uuid::Uuid;
+
+#[get("/{id}")]
+pub async fn query_contact_details(
+    data: Data<AppState>,
+    _: ApiKeyHeader,
+    user: LoggedIn,
+    contact_id: Path<Uuid>,
+    request_query: RequestType<Contact, QueryablePlaceholder, SortablePlaceholder>,
+) -> Result<impl Responder> {
+    let pool = &data.db;
+    let user = user.0;
+    let contact_id = contact_id.into_inner();
+    let fetch_level = request_query.fetch_level.as_ref();
+    let descendant_fetch_level = request_query.descendant_fetch_level.as_ref();
+    let authorizer =
+        permissions::get_authorizer(pool, &user, format!("/contacts/{contact_id}")).await?;
+
+    let contact = Contact::get_by_id(
+        pool,
+        contact_id,
+        fetch_level,
+        descendant_fetch_level,
+        &authorizer,
+    )
+    .await?;
+    let response = ResponseType::new(contact, None);
+
+    Ok(HttpResponse::Ok().json(response))
+}

--- a/mysk-data-api/src/routes/v1/contacts/query_contacts.rs
+++ b/mysk-data-api/src/routes/v1/contacts/query_contacts.rs
@@ -1,0 +1,53 @@
+use crate::{
+    extractors::{api_key::ApiKeyHeader, logged_in::LoggedIn},
+    AppState,
+};
+use actix_web::{get, web::Data, HttpResponse, Responder};
+use mysk_lib::{
+    common::{
+        requests::RequestType,
+        response::{MetadataType, ResponseType},
+    },
+    models::{
+        contact::{
+            request::{queryable::QueryableContact, sortable::SortableContact},
+            Contact,
+        },
+        traits::TopLevelQuery as _,
+    },
+    permissions,
+    prelude::*,
+};
+
+#[get("")]
+pub async fn query_contacts(
+    data: Data<AppState>,
+    _: ApiKeyHeader,
+    user: LoggedIn,
+    request_query: RequestType<Contact, QueryableContact, SortableContact>,
+) -> Result<impl Responder> {
+    let pool = &data.db;
+    let user = user.0;
+    let fetch_level = request_query.fetch_level.as_ref();
+    let descendant_fetch_level = request_query.descendant_fetch_level.as_ref();
+    let filter = request_query.filter.as_ref();
+    let sort = request_query.sort.as_ref();
+    let pagination = request_query.pagination.as_ref();
+    let authorizer = permissions::get_authorizer(pool, &user, "/contacts".to_string()).await?;
+
+    let contacts = Contact::query(
+        pool,
+        fetch_level,
+        descendant_fetch_level,
+        filter,
+        sort,
+        pagination,
+        &authorizer,
+    )
+    .await?;
+
+    let pagination = Contact::response_pagination(pool, filter, pagination).await?;
+    let response = ResponseType::new(contacts, Some(MetadataType::new(Some(pagination))));
+
+    Ok(HttpResponse::Ok().json(response))
+}

--- a/mysk-data-api/src/routes/v1/mod.rs
+++ b/mysk-data-api/src/routes/v1/mod.rs
@@ -1,12 +1,14 @@
 use actix_web::web::{scope, ServiceConfig};
 
 pub mod clubs;
+pub mod contacts;
 pub mod students;
 pub mod subjects;
 pub mod teachers;
 
 pub fn config(cfg: &mut ServiceConfig) {
     cfg.service(scope("/clubs").configure(clubs::config));
+    cfg.service(scope("/contacts").configure(contacts::config));
     cfg.service(scope("/students").configure(students::config));
     cfg.service(scope("/teachers").configure(teachers::config));
     cfg.service(scope("/subjects").configure(subjects::config));

--- a/mysk-lib/src/common/requests.rs
+++ b/mysk-lib/src/common/requests.rs
@@ -1,5 +1,10 @@
-use crate::models::traits::Queryable;
-use crate::{models::enums::SubmissionStatus, prelude::*};
+use crate::{
+    models::{
+        enums::{ContactType, SubmissionStatus},
+        traits::Queryable,
+    },
+    prelude::*,
+};
 use actix_web::{dev::Payload, FromRequest, HttpRequest};
 use futures::future;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -161,6 +166,7 @@ pub enum QueryParam {
     ArrayBool(Vec<bool>),
     ArrayUuid(Vec<Uuid>),
     SubmissionStatus(SubmissionStatus),
+    ContactType(ContactType),
 }
 
 impl Encode<'_, Postgres> for QueryParam {
@@ -182,6 +188,7 @@ impl Encode<'_, Postgres> for QueryParam {
             QueryParam::SubmissionStatus(v) => {
                 <SubmissionStatus as sqlx::Encode<Postgres>>::encode(*v, buf)
             }
+            QueryParam::ContactType(v) => <ContactType as sqlx::Encode<Postgres>>::encode(*v, buf),
         }
     }
 }

--- a/mysk-lib/src/models/contact/db.rs
+++ b/mysk-lib/src/models/contact/db.rs
@@ -1,18 +1,33 @@
-use crate::models::enums::ContactType;
+use crate::{
+    common::{
+        requests::{FilterConfig, PaginationConfig, QueryParam, SortingConfig, SqlSection},
+        response::PaginationType,
+    },
+    models::{
+        contact::request::{queryable::QueryableContact, sortable::SortableContact},
+        enums::ContactType,
+        traits::{QueryDb, Queryable as _},
+    },
+    prelude::*,
+};
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use mysk_lib_derives::{BaseQuery, GetById};
 use mysk_lib_macros::traits::db::{BaseQuery, GetById};
 use serde::Deserialize;
-use sqlx::FromRow;
+use sqlx::{FromRow, PgPool, Postgres, QueryBuilder, Row as _};
 use uuid::Uuid;
 
 #[derive(BaseQuery, Clone, Debug, Deserialize, FromRow, GetById)]
-#[base_query(query = "
+#[base_query(
+    query = "
     SELECT
         id, created_at, name_th, name_en, type, value, include_students, include_teachers,
         include_parents
     FROM contacts
-")]
+    ",
+    count_query = "SELECT COUNT(*) FROM contacts"
+)]
 pub struct DbContact {
     pub id: Uuid,
     pub created_at: Option<DateTime<Utc>>,
@@ -23,4 +38,93 @@ pub struct DbContact {
     pub include_students: Option<bool>,
     pub include_teachers: Option<bool>,
     pub include_parents: Option<bool>,
+}
+
+#[async_trait]
+impl QueryDb<QueryableContact, SortableContact> for DbContact {
+    fn build_shared_query(
+        query_builder: &mut QueryBuilder<'_, Postgres>,
+        filter: Option<&FilterConfig<QueryableContact>>,
+    ) {
+        let mut where_sections: Vec<SqlSection> = Vec::new();
+
+        if let Some(filter) = filter {
+            if let Some(data) = &filter.data {
+                let mut data_sections = data.to_query_string();
+                where_sections.append(&mut data_sections);
+            }
+        }
+
+        for (i, section) in where_sections.iter().enumerate() {
+            query_builder.push(if i == 0 { " WHERE " } else { " AND " });
+            for (j, sql) in section.sql.iter().enumerate() {
+                query_builder.push(sql);
+                if j < section.params.len() {
+                    match section.params.get(j) {
+                        Some(QueryParam::Bool(v)) => query_builder.push_bind(*v),
+                        Some(QueryParam::String(v)) => query_builder.push_bind(v.clone()),
+                        Some(QueryParam::ArrayUuid(v)) => query_builder.push_bind(v.clone()),
+                        Some(QueryParam::ContactType(v)) => query_builder.push_bind(*v),
+                        _ => unreachable!(),
+                    };
+                }
+            }
+        }
+    }
+
+    async fn query(
+        pool: &PgPool,
+        filter: Option<&FilterConfig<QueryableContact>>,
+        sort: Option<&SortingConfig<SortableContact>>,
+        pagination: Option<&PaginationConfig>,
+    ) -> Result<Vec<Self>> {
+        let mut query = QueryBuilder::new(DbContact::base_query());
+        Self::build_shared_query(&mut query, filter);
+
+        if let Some(sorting) = sort {
+            query.push(sorting.to_order_by_clause());
+        }
+
+        if let Some(pagination) = pagination {
+            let limit_section = pagination.to_limit_clause()?;
+            query.push(" ");
+            for (i, sql) in limit_section.sql.iter().enumerate() {
+                query.push(sql);
+                if i < limit_section.params.len() {
+                    match limit_section.params.get(i) {
+                        Some(&QueryParam::Int(v)) => query.push_bind(v),
+                        _ => {
+                            return Err(Error::InternalSeverError(
+                                "Invalid pagination params".to_string(),
+                                "DbContact::query".to_string(),
+                            ));
+                        }
+                    };
+                }
+            }
+        }
+
+        Ok(query.build_query_as::<DbContact>().fetch_all(pool).await?)
+    }
+
+    async fn response_pagination(
+        pool: &PgPool,
+        filter: Option<&FilterConfig<QueryableContact>>,
+        pagination: Option<&PaginationConfig>,
+    ) -> Result<PaginationType> {
+        let mut query = QueryBuilder::new(DbContact::count_query());
+        Self::build_shared_query(&mut query, filter);
+
+        let count = u32::try_from(query.build().fetch_one(pool).await?.get::<i64, _>("count"))
+            .expect("Irrecoverable error, i64 is out of bounds for u32");
+
+        Ok(PaginationType::new(
+            pagination.unwrap_or(&PaginationConfig::default()).p,
+            pagination
+                .unwrap_or(&PaginationConfig::default())
+                .size
+                .unwrap_or(50),
+            count,
+        ))
+    }
 }

--- a/mysk-lib/src/models/contact/fetch_levels/default.rs
+++ b/mysk-lib/src/models/contact/fetch_levels/default.rs
@@ -1,0 +1,52 @@
+use crate::{
+    common::{requests::FetchLevel, string::FlexibleMultiLangString},
+    models::{contact::db::DbContact, enums::ContactType, traits::FetchLevelVariant},
+    permissions::{ActionType, Authorizer},
+    prelude::*,
+};
+use async_trait::async_trait;
+use mysk_lib_macros::impl_fetch_level_variant_from;
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct DefaultContact {
+    pub id: Uuid,
+    pub name: Option<FlexibleMultiLangString>,
+    pub r#type: ContactType,
+    pub value: String,
+    pub include_students: Option<bool>,
+    pub include_teachers: Option<bool>,
+    pub include_parents: Option<bool>,
+}
+
+impl From<DbContact> for DefaultContact {
+    fn from(contact: DbContact) -> Self {
+        Self {
+            id: contact.id,
+            name: match (contact.name_th, contact.name_en) {
+                (Some(name_th), Some(name_en)) => Some(FlexibleMultiLangString {
+                    th: Some(name_th),
+                    en: Some(name_en),
+                }),
+                (Some(name_th), None) => Some(FlexibleMultiLangString {
+                    th: Some(name_th),
+                    en: None,
+                }),
+                (None, Some(name_en)) => Some(FlexibleMultiLangString {
+                    th: None,
+                    en: Some(name_en),
+                }),
+                (None, None) => None,
+            },
+            r#type: contact.r#type,
+            value: contact.value,
+            include_students: contact.include_students,
+            include_teachers: contact.include_teachers,
+            include_parents: contact.include_parents,
+        }
+    }
+}
+
+impl_fetch_level_variant_from!(contact, Default, DefaultContact, DbContact);

--- a/mysk-lib/src/models/contact/fetch_levels/id_only.rs
+++ b/mysk-lib/src/models/contact/fetch_levels/id_only.rs
@@ -1,0 +1,17 @@
+use crate::{
+    common::requests::FetchLevel,
+    models::{contact::db::DbContact, traits::FetchLevelVariant},
+    permissions::{ActionType, Authorizer},
+    prelude::*,
+};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdOnlyContact {
+    pub id: Uuid,
+}
+
+mysk_lib_macros::impl_id_only_variant_from!(contact, IdOnlyContact, DbContact);

--- a/mysk-lib/src/models/contact/fetch_levels/mod.rs
+++ b/mysk-lib/src/models/contact/fetch_levels/mod.rs
@@ -1,0 +1,2 @@
+pub mod default;
+pub mod id_only;

--- a/mysk-lib/src/models/contact/mod.rs
+++ b/mysk-lib/src/models/contact/mod.rs
@@ -1,131 +1,125 @@
-use crate::{
-    common::{requests::FetchLevel, string::FlexibleMultiLangString},
-    models::{
-        contact::db::DbContact,
-        enums::ContactType,
-        traits::{TopLevelFromTable, TopLevelGetById},
-    },
-    permissions::{ActionType, Authorizer},
-    prelude::*,
-};
-use async_trait::async_trait;
-use chrono::{DateTime, Utc};
-use mysk_lib_macros::traits::db::GetById;
-use serde::{Deserialize, Serialize};
-use sqlx::PgPool;
-use uuid::Uuid;
+use crate::models::contact::db::DbContact;
+use fetch_levels::{default::DefaultContact, id_only::IdOnlyContact};
+
+use super::{top_level_variant::TopLevelVariant, traits::TopLevelQuery};
 
 pub mod db;
+pub mod fetch_levels;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct Contact {
-    pub id: Uuid,
-    pub created_at: Option<DateTime<Utc>>,
-    pub name: Option<FlexibleMultiLangString>,
-    pub r#type: ContactType,
-    pub value: String,
-    pub include_students: Option<bool>,
-    pub include_teachers: Option<bool>,
-    pub include_parents: Option<bool>,
-}
+pub type Contact =
+    TopLevelVariant<DbContact, IdOnlyContact, IdOnlyContact, DefaultContact, DefaultContact>;
 
-#[async_trait]
-impl TopLevelFromTable<DbContact> for Contact {
-    async fn from_table(
-        pool: &PgPool,
-        table: DbContact,
-        _: Option<&FetchLevel>,
-        _: Option<&FetchLevel>,
-        authorizer: &Box<dyn Authorizer>,
-    ) -> Result<Self> {
-        authorizer
-            .authorize_contact(&table, pool, ActionType::ReadDefault)
-            .await?;
+// impl TopLevelQuery<DbContact, QueryablePlaceholder, SortablePlaceholder> for Contact {}
 
-        Ok(Self {
-            id: table.id,
-            created_at: table.created_at,
-            name: match (table.name_th, table.name_en) {
-                (Some(name_th), Some(name_en)) => Some(FlexibleMultiLangString {
-                    th: Some(name_th),
-                    en: Some(name_en),
-                }),
-                (Some(name_th), None) => Some(FlexibleMultiLangString {
-                    th: Some(name_th),
-                    en: None,
-                }),
-                (None, Some(name_en)) => Some(FlexibleMultiLangString {
-                    th: None,
-                    en: Some(name_en),
-                }),
-                (None, None) => None,
-            },
-            r#type: table.r#type,
-            value: table.value,
-            include_students: table.include_students,
-            include_teachers: table.include_teachers,
-            include_parents: table.include_parents,
-        })
-    }
-}
+// #[derive(Clone, Debug, Deserialize, Serialize)]
+// pub struct Contact {
+//     pub id: Uuid,
+//     pub created_at: Option<DateTime<Utc>>,
+//     pub name: Option<FlexibleMultiLangString>,
+//     pub r#type: ContactType,
+//     pub value: String,
+//     pub include_students: Option<bool>,
+//     pub include_teachers: Option<bool>,
+//     pub include_parents: Option<bool>,
+// }
 
-#[async_trait]
-impl TopLevelGetById for Contact {
-    type Id = Uuid;
+// #[async_trait]
+// impl TopLevelFromTable<DbContact> for Contact {
+//     async fn from_table(
+//         pool: &PgPool,
+//         table: DbContact,
+//         _: Option<&FetchLevel>,
+//         _: Option<&FetchLevel>,
+//         authorizer: &Box<dyn Authorizer>,
+//     ) -> Result<Self> {
+//         authorizer
+//             .authorize_contact(&table, pool, ActionType::ReadDefault)
+//             .await?;
 
-    async fn get_by_id(
-        pool: &PgPool,
-        id: Self::Id,
-        fetch_level: Option<&FetchLevel>,
-        descendant_fetch_level: Option<&FetchLevel>,
-        authorizer: &Box<dyn Authorizer>,
-    ) -> Result<Self> {
-        let contact = DbContact::get_by_id(pool, id).await?;
+//         Ok(Self {
+//             id: table.id,
+//             created_at: table.created_at,
+//             name: match (table.name_th, table.name_en) {
+//                 (Some(name_th), Some(name_en)) => Some(FlexibleMultiLangString {
+//                     th: Some(name_th),
+//                     en: Some(name_en),
+//                 }),
+//                 (Some(name_th), None) => Some(FlexibleMultiLangString {
+//                     th: Some(name_th),
+//                     en: None,
+//                 }),
+//                 (None, Some(name_en)) => Some(FlexibleMultiLangString {
+//                     th: None,
+//                     en: Some(name_en),
+//                 }),
+//                 (None, None) => None,
+//             },
+//             r#type: table.r#type,
+//             value: table.value,
+//             include_students: table.include_students,
+//             include_teachers: table.include_teachers,
+//             include_parents: table.include_parents,
+//         })
+//     }
+// }
 
-        Self::from_table(
-            pool,
-            contact,
-            fetch_level,
-            descendant_fetch_level,
-            authorizer,
-        )
-        .await
-    }
+// #[async_trait]
+// impl TopLevelGetById for Contact {
+//     type Id = Uuid;
 
-    async fn get_by_ids(
-        pool: &PgPool,
-        ids: Vec<Self::Id>,
-        fetch_level: Option<&FetchLevel>,
-        descendant_fetch_level: Option<&FetchLevel>,
-        authorizer: &Box<dyn Authorizer>,
-    ) -> Result<Vec<Self>> {
-        let contacts = DbContact::get_by_ids(pool, ids).await?;
-        let fetch_level = fetch_level.copied();
-        let descendant_fetch_level = descendant_fetch_level.copied();
-        let futures: Vec<_> = contacts
-            .into_iter()
-            .map(|contact| {
-                let pool = pool.clone();
-                let authorizer = dyn_clone::clone_box(&**authorizer);
+//     async fn get_by_id(
+//         pool: &PgPool,
+//         id: Self::Id,
+//         fetch_level: Option<&FetchLevel>,
+//         descendant_fetch_level: Option<&FetchLevel>,
+//         authorizer: &Box<dyn Authorizer>,
+//     ) -> Result<Self> {
+//         let contact = DbContact::get_by_id(pool, id).await?;
 
-                tokio::spawn(async move {
-                    Self::from_table(
-                        &pool,
-                        contact,
-                        fetch_level.as_ref(),
-                        descendant_fetch_level.as_ref(),
-                        &authorizer,
-                    )
-                    .await
-                })
-            })
-            .collect();
+//         Self::from_table(
+//             pool,
+//             contact,
+//             fetch_level,
+//             descendant_fetch_level,
+//             authorizer,
+//         )
+//         .await
+//     }
 
-        let mut result = Vec::with_capacity(futures.len());
-        for future in futures {
-            result.push(future.await??);
-        }
+//     async fn get_by_ids(
+//         pool: &PgPool,
+//         ids: Vec<Self::Id>,
+//         fetch_level: Option<&FetchLevel>,
+//         descendant_fetch_level: Option<&FetchLevel>,
+//         authorizer: &Box<dyn Authorizer>,
+//     ) -> Result<Vec<Self>> {
+//         let contacts = DbContact::get_by_ids(pool, ids).await?;
+//         let fetch_level = fetch_level.copied();
+//         let descendant_fetch_level = descendant_fetch_level.copied();
+//         let futures: Vec<_> = contacts
+//             .into_iter()
+//             .map(|contact| {
+//                 let pool = pool.clone();
+//                 let authorizer = dyn_clone::clone_box(&**authorizer);
 
-        Ok(result)
-    }
-}
+//                 tokio::spawn(async move {
+//                     Self::from_table(
+//                         &pool,
+//                         contact,
+//                         fetch_level.as_ref(),
+//                         descendant_fetch_level.as_ref(),
+//                         &authorizer,
+//                     )
+//                     .await
+//                 })
+//             })
+//             .collect();
+
+//         let mut result = Vec::with_capacity(futures.len());
+//         for future in futures {
+//             result.push(future.await??);
+//         }
+
+//         Ok(result)
+//     }
+// }

--- a/mysk-lib/src/models/contact/mod.rs
+++ b/mysk-lib/src/models/contact/mod.rs
@@ -1,125 +1,18 @@
-use crate::models::contact::db::DbContact;
-use fetch_levels::{default::DefaultContact, id_only::IdOnlyContact};
-
-use super::{top_level_variant::TopLevelVariant, traits::TopLevelQuery};
+use crate::models::{
+    contact::db::DbContact,
+    contact::{
+        fetch_levels::{default::DefaultContact, id_only::IdOnlyContact},
+        request::{queryable::QueryableContact, sortable::SortableContact},
+    },
+    top_level_variant::TopLevelVariant,
+    traits::TopLevelQuery,
+};
 
 pub mod db;
 pub mod fetch_levels;
+pub mod request;
 
 pub type Contact =
     TopLevelVariant<DbContact, IdOnlyContact, IdOnlyContact, DefaultContact, DefaultContact>;
 
-// impl TopLevelQuery<DbContact, QueryablePlaceholder, SortablePlaceholder> for Contact {}
-
-// #[derive(Clone, Debug, Deserialize, Serialize)]
-// pub struct Contact {
-//     pub id: Uuid,
-//     pub created_at: Option<DateTime<Utc>>,
-//     pub name: Option<FlexibleMultiLangString>,
-//     pub r#type: ContactType,
-//     pub value: String,
-//     pub include_students: Option<bool>,
-//     pub include_teachers: Option<bool>,
-//     pub include_parents: Option<bool>,
-// }
-
-// #[async_trait]
-// impl TopLevelFromTable<DbContact> for Contact {
-//     async fn from_table(
-//         pool: &PgPool,
-//         table: DbContact,
-//         _: Option<&FetchLevel>,
-//         _: Option<&FetchLevel>,
-//         authorizer: &Box<dyn Authorizer>,
-//     ) -> Result<Self> {
-//         authorizer
-//             .authorize_contact(&table, pool, ActionType::ReadDefault)
-//             .await?;
-
-//         Ok(Self {
-//             id: table.id,
-//             created_at: table.created_at,
-//             name: match (table.name_th, table.name_en) {
-//                 (Some(name_th), Some(name_en)) => Some(FlexibleMultiLangString {
-//                     th: Some(name_th),
-//                     en: Some(name_en),
-//                 }),
-//                 (Some(name_th), None) => Some(FlexibleMultiLangString {
-//                     th: Some(name_th),
-//                     en: None,
-//                 }),
-//                 (None, Some(name_en)) => Some(FlexibleMultiLangString {
-//                     th: None,
-//                     en: Some(name_en),
-//                 }),
-//                 (None, None) => None,
-//             },
-//             r#type: table.r#type,
-//             value: table.value,
-//             include_students: table.include_students,
-//             include_teachers: table.include_teachers,
-//             include_parents: table.include_parents,
-//         })
-//     }
-// }
-
-// #[async_trait]
-// impl TopLevelGetById for Contact {
-//     type Id = Uuid;
-
-//     async fn get_by_id(
-//         pool: &PgPool,
-//         id: Self::Id,
-//         fetch_level: Option<&FetchLevel>,
-//         descendant_fetch_level: Option<&FetchLevel>,
-//         authorizer: &Box<dyn Authorizer>,
-//     ) -> Result<Self> {
-//         let contact = DbContact::get_by_id(pool, id).await?;
-
-//         Self::from_table(
-//             pool,
-//             contact,
-//             fetch_level,
-//             descendant_fetch_level,
-//             authorizer,
-//         )
-//         .await
-//     }
-
-//     async fn get_by_ids(
-//         pool: &PgPool,
-//         ids: Vec<Self::Id>,
-//         fetch_level: Option<&FetchLevel>,
-//         descendant_fetch_level: Option<&FetchLevel>,
-//         authorizer: &Box<dyn Authorizer>,
-//     ) -> Result<Vec<Self>> {
-//         let contacts = DbContact::get_by_ids(pool, ids).await?;
-//         let fetch_level = fetch_level.copied();
-//         let descendant_fetch_level = descendant_fetch_level.copied();
-//         let futures: Vec<_> = contacts
-//             .into_iter()
-//             .map(|contact| {
-//                 let pool = pool.clone();
-//                 let authorizer = dyn_clone::clone_box(&**authorizer);
-
-//                 tokio::spawn(async move {
-//                     Self::from_table(
-//                         &pool,
-//                         contact,
-//                         fetch_level.as_ref(),
-//                         descendant_fetch_level.as_ref(),
-//                         &authorizer,
-//                     )
-//                     .await
-//                 })
-//             })
-//             .collect();
-
-//         let mut result = Vec::with_capacity(futures.len());
-//         for future in futures {
-//             result.push(future.await??);
-//         }
-
-//         Ok(result)
-//     }
-// }
+impl TopLevelQuery<DbContact, QueryableContact, SortableContact> for Contact {}

--- a/mysk-lib/src/models/contact/request/mod.rs
+++ b/mysk-lib/src/models/contact/request/mod.rs
@@ -1,0 +1,2 @@
+pub mod queryable;
+pub mod sortable;

--- a/mysk-lib/src/models/contact/request/queryable.rs
+++ b/mysk-lib/src/models/contact/request/queryable.rs
@@ -1,0 +1,142 @@
+use crate::{
+    common::requests::{QueryParam, SqlSection},
+    models::{enums::ContactType, traits::Queryable},
+};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct QueryableContact {
+    pub ids: Option<Vec<Uuid>>,
+    pub name: Option<String>,
+    pub r#type: Option<ContactType>,
+    pub value: Option<String>,
+    pub classroom_ids: Option<Vec<Uuid>>,
+    pub club_ids: Option<Vec<Uuid>>,
+    pub student_ids: Option<Vec<Uuid>>,
+    pub teacher_ids: Option<Vec<Uuid>>,
+    pub include_students: Option<bool>,
+    pub include_teachers: Option<bool>,
+    pub include_parents: Option<bool>,
+}
+
+impl Queryable for QueryableContact {
+    fn to_query_string(&self) -> Vec<SqlSection> {
+        let mut where_sections = Vec::<SqlSection>::new();
+
+        // WHERE id = ANY($1)
+        if let Some(ids) = &self.ids {
+            where_sections.push(SqlSection {
+                sql: vec!["id = ANY(".to_string(), ")".to_string()],
+                params: vec![QueryParam::ArrayUuid(ids.clone())],
+            });
+        }
+
+        // WHERE name_th ILIKE $1 OR name_en ILIKE $1
+        // https://stackoverflow.com/questions/77625753/using-ilike-in-rust-sqlx-with-push-bind
+        if let Some(name) = &self.name {
+            where_sections.push(SqlSection {
+                sql: vec![
+                    "(name_th ILIKE ".to_string(),
+                    " OR name_en ILIKE ".to_string(),
+                    ")".to_string(),
+                ],
+                params: vec![
+                    QueryParam::String(name.clone()),
+                    QueryParam::String(name.clone()),
+                ],
+            });
+        }
+
+        // WHERE type = $1
+        if let Some(r#type) = &self.r#type {
+            where_sections.push(SqlSection {
+                sql: vec!["type = ".to_string()],
+                params: vec![QueryParam::ContactType(*r#type)],
+            });
+        }
+
+        // WHERE value ILIKE $1
+        if let Some(value) = &self.value {
+            where_sections.push(SqlSection {
+                sql: vec!["value ILIKE ".to_string()],
+                params: vec![QueryParam::String(value.clone())],
+            });
+        }
+
+        // WHERE id IN (SELECT contact_id FROM classroom_contacts WHERE classroom_id = ANY($1))
+        if let Some(classroom_ids) = &self.classroom_ids {
+            where_sections.push(SqlSection {
+                sql: vec![
+                    "id IN (SELECT contact_id FROM classroom_contacts WHERE classroom_id = ANY("
+                        .to_string(),
+                    "))".to_string(),
+                ],
+                params: vec![QueryParam::ArrayUuid(classroom_ids.clone())],
+            });
+        }
+
+        // WHERE id IN (SELECT contact_id FROM club_contacts WHERE club_id = ANY($1))
+        if let Some(club_ids) = &self.club_ids {
+            where_sections.push(SqlSection {
+                sql: vec![
+                    "id IN (SELECT contact_id FROM club_contacts WHERE club_id = ANY(".to_string(),
+                    "))".to_string(),
+                ],
+                params: vec![QueryParam::ArrayUuid(club_ids.clone())],
+            });
+        }
+
+        // WHERE id IN (SELECT contact_id FROM person_contacts WHERE person_id = ANY(SELECT
+        // person_id FROM students WHERE id = ANY($1)))
+        if let Some(student_ids) = &self.student_ids {
+            where_sections.push(SqlSection {
+                sql: vec![
+                    "id IN (SELECT contact_id FROM person_contacts WHERE person_id = ANY(SELECT person_id FROM students WHERE id = ANY("
+                        .to_string(),
+                    "))".to_string(),
+                ],
+                params: vec![QueryParam::ArrayUuid(student_ids.clone())],
+            });
+        }
+
+        // WHERE id IN (SELECT contact_id FROM person_contacts WHERE person_id = ANY(SELECT
+        // person_id FROM teachers WHERE id = ANY($1)))
+        if let Some(teacher_ids) = &self.teacher_ids {
+            where_sections.push(SqlSection {
+                sql: vec![
+                    "id IN (SELECT contact_id FROM person_contacts WHERE person_id = ANY(SELECT person_id FROM teachers WHERE id = ANY("
+                        .to_string(),
+                    "))".to_string(),
+                ],
+                params: vec![QueryParam::ArrayUuid(teacher_ids.clone())],
+            });
+        }
+
+        // WHERE include_students = $1
+        if let Some(include_students) = &self.include_students {
+            where_sections.push(SqlSection {
+                sql: vec!["include_students ILIKE ".to_string()],
+                params: vec![QueryParam::Bool(*include_students)],
+            });
+        }
+
+        // WHERE include_teachers = $1
+        if let Some(include_teachers) = &self.include_teachers {
+            where_sections.push(SqlSection {
+                sql: vec!["include_teachers ILIKE ".to_string()],
+                params: vec![QueryParam::Bool(*include_teachers)],
+            });
+        }
+
+        // WHERE include_parents = $1
+        if let Some(include_parents) = &self.include_parents {
+            where_sections.push(SqlSection {
+                sql: vec!["include_parents ILIKE ".to_string()],
+                params: vec![QueryParam::Bool(*include_parents)],
+            });
+        }
+
+        where_sections
+    }
+}

--- a/mysk-lib/src/models/contact/request/queryable.rs
+++ b/mysk-lib/src/models/contact/request/queryable.rs
@@ -94,7 +94,7 @@ impl Queryable for QueryableContact {
                 sql: vec![
                     "id IN (SELECT contact_id FROM person_contacts WHERE person_id = ANY(SELECT person_id FROM students WHERE id = ANY("
                         .to_string(),
-                    "))".to_string(),
+                    ")))".to_string(),
                 ],
                 params: vec![QueryParam::ArrayUuid(student_ids.clone())],
             });
@@ -107,7 +107,7 @@ impl Queryable for QueryableContact {
                 sql: vec![
                     "id IN (SELECT contact_id FROM person_contacts WHERE person_id = ANY(SELECT person_id FROM teachers WHERE id = ANY("
                         .to_string(),
-                    "))".to_string(),
+                    ")))".to_string(),
                 ],
                 params: vec![QueryParam::ArrayUuid(teacher_ids.clone())],
             });

--- a/mysk-lib/src/models/contact/request/sortable.rs
+++ b/mysk-lib/src/models/contact/request/sortable.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SortableContact {
+    Id,
+    Name,
+    Type,
+    IncludeStudents,
+    IncludeTeachers,
+    IncludeParents,
+}
+
+impl Default for SortableContact {
+    fn default() -> Self {
+        Self::Id
+    }
+}
+
+impl Display for SortableContact {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SortableContact::Id => write!(f, "id"),
+            SortableContact::Name => write!(f, "name"),
+            SortableContact::Type => write!(f, "type"),
+            SortableContact::IncludeStudents => write!(f, "include_students"),
+            SortableContact::IncludeTeachers => write!(f, "include_teachers"),
+            SortableContact::IncludeParents => write!(f, "include_parents"),
+        }
+    }
+}

--- a/mysk-lib/src/models/elective_trade_offer/db.rs
+++ b/mysk-lib/src/models/elective_trade_offer/db.rs
@@ -40,9 +40,7 @@ impl QueryDb<QueryableElectiveTradeOffer, SortableElectiveTradeOffer> for DbElec
     fn build_shared_query(
         query_builder: &mut QueryBuilder<'_, Postgres>,
         filter: Option<&FilterConfig<QueryableElectiveTradeOffer>>,
-    ) where
-        Self: Sized,
-    {
+    ) {
         let mut where_sections: Vec<SqlSection> = Vec::new();
 
         if let Some(filter) = filter {
@@ -72,10 +70,7 @@ impl QueryDb<QueryableElectiveTradeOffer, SortableElectiveTradeOffer> for DbElec
         filter: Option<&FilterConfig<QueryableElectiveTradeOffer>>,
         sort: Option<&SortingConfig<SortableElectiveTradeOffer>>,
         pagination: Option<&PaginationConfig>,
-    ) -> Result<Vec<Self>>
-    where
-        Self: Sized,
-    {
+    ) -> Result<Vec<Self>> {
         let mut query = QueryBuilder::new(DbElectiveTradeOffer::base_query());
         Self::build_shared_query(&mut query, filter);
 


### PR DESCRIPTION
Get contact by ID => `GET /v1/contacts/{id}`
Query contacts => `GET /v1/contacts`
Update contact by ID => `PUT /v1/contacts/{id}`
Delete contacts => `POST /v1/contacts`

Nothing much in this PR, except that it resolves BACK-91. I also discovered that `Arc<T>` was the gateway to fix all (most) of my async lifetime problems. Hooray! Borrow checker FTW