### PR TITLE
Beta Release 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
     "Phawat Suksiriwan <phawat@suksiriwan.com>",
     "owo93 <Iztyle30@gmail.com>",
 ]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 [workspace.dependencies]

--- a/mysk-data-api/src/routes/v1/subjects/electives/enroll_electives.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/enroll_electives.rs
@@ -67,7 +67,7 @@ pub async fn enroll_elective_subject(
     };
 
     // Check if the current time is within the elective's enrollment period
-    if !DbElectiveSubject::is_enrollment_period(pool).await? {
+    if !DbElectiveSubject::is_enrollment_period(pool, student_id).await? {
         return Err(Error::InvalidPermission(
             "The elective's enrollment period has ended".to_string(),
             format!("/subjects/electives/{elective_subject_session_id}/enroll"),

--- a/mysk-data-api/src/routes/v1/subjects/electives/get_previously_enrolled.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/get_previously_enrolled.rs
@@ -1,0 +1,23 @@
+use crate::{
+    extractors::{api_key::ApiKeyHeader, student::LoggedInStudent},
+    AppState,
+};
+use actix_web::{get, web::Data, HttpResponse, Responder};
+use mysk_lib::{
+    common::response::ResponseType, models::elective_subject::db::DbElectiveSubject, prelude::*,
+};
+
+#[get("/previously-enrolled")]
+async fn get_previously_enrolled(
+    data: Data<AppState>,
+    _: ApiKeyHeader,
+    student_id: LoggedInStudent,
+) -> Result<impl Responder> {
+    let pool = &data.db;
+    let student_id = student_id.0;
+
+    let electives = DbElectiveSubject::get_previously_enrolled_electives(pool, student_id).await?;
+    let response = ResponseType::new(electives, None);
+
+    Ok(HttpResponse::Ok().json(response))
+}

--- a/mysk-data-api/src/routes/v1/subjects/electives/in_enrollment_period.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/in_enrollment_period.rs
@@ -1,14 +1,22 @@
-use crate::{extractors::api_key::ApiKeyHeader, AppState};
+use crate::{
+    extractors::{api_key::ApiKeyHeader, student::LoggedInStudent},
+    AppState,
+};
 use actix_web::{get, web::Data, HttpResponse, Responder};
 use mysk_lib::{
     common::response::ResponseType, models::elective_subject::db::DbElectiveSubject, prelude::*,
 };
 
 #[get("/in-enrollment-period")]
-pub async fn in_enrollment_period(data: Data<AppState>, _: ApiKeyHeader) -> Result<impl Responder> {
+pub async fn in_enrollment_period(
+    data: Data<AppState>,
+    _: ApiKeyHeader,
+    student_id: LoggedInStudent,
+) -> Result<impl Responder> {
     let pool = &data.db;
+    let student_id = student_id.0;
 
-    let is_in_enrollment_period = DbElectiveSubject::is_enrollment_period(pool).await?;
+    let is_in_enrollment_period = DbElectiveSubject::is_enrollment_period(pool, student_id).await?;
     let response = ResponseType::new(is_in_enrollment_period, None);
 
     Ok(HttpResponse::Ok().json(response))

--- a/mysk-data-api/src/routes/v1/subjects/electives/mod.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/mod.rs
@@ -1,6 +1,7 @@
 use actix_web::web::{scope, ServiceConfig};
 
 pub mod enroll_electives;
+pub mod get_previously_enrolled;
 pub mod in_enrollment_period;
 pub mod modify_electives;
 pub mod query_elective_details;
@@ -9,6 +10,7 @@ pub mod trade_offers;
 
 pub fn config(cfg: &mut ServiceConfig) {
     cfg.service(scope("/trade-offers").configure(trade_offers::config));
+    cfg.service(get_previously_enrolled::get_previously_enrolled);
     cfg.service(in_enrollment_period::in_enrollment_period);
     cfg.service(enroll_electives::enroll_elective_subject);
     cfg.service(modify_electives::modify_elective_subject);

--- a/mysk-data-api/src/routes/v1/subjects/electives/modify_electives.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/modify_electives.rs
@@ -39,7 +39,7 @@ async fn modify_elective_subject(
     let descendant_fetch_level = request_body.descendant_fetch_level.as_ref();
 
     // Check if the current time is within the elective's enrollment period
-    if !DbElectiveSubject::is_enrollment_period(pool).await? {
+    if !DbElectiveSubject::is_enrollment_period(pool, student_id).await? {
         return Err(Error::InvalidPermission(
             "The elective's enrollment period has ended".to_string(),
             format!("/subjects/electives/{elective_subject_session_id}/enroll"),

--- a/mysk-data-api/src/routes/v1/subjects/electives/trade_offers/create_offer.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/trade_offers/create_offer.rs
@@ -55,7 +55,7 @@ async fn create_trade_offer(
     let descendant_fetch_level = request_body.descendant_fetch_level.as_ref();
 
     // Check if the current time is within the elective's enrollment period
-    if !DbElectiveSubject::is_enrollment_period(pool).await? {
+    if !DbElectiveSubject::is_enrollment_period(pool, sender_student_id).await? {
         return Err(Error::InvalidPermission(
             "The elective's enrollment period has ended".to_string(),
             "/subjects/electives/trade-offers".to_string(),

--- a/mysk-data-api/src/routes/v1/subjects/electives/trade_offers/update_offer.rs
+++ b/mysk-data-api/src/routes/v1/subjects/electives/trade_offers/update_offer.rs
@@ -64,7 +64,7 @@ async fn update_trade_offer(
     let descendant_fetch_level = request_body.descendant_fetch_level.as_ref();
 
     // Check if the current time is within the elective's enrollment period
-    if !DbElectiveSubject::is_enrollment_period(pool).await? {
+    if !DbElectiveSubject::is_enrollment_period(pool, client_student_id).await? {
         return Err(Error::InvalidPermission(
             "The elective's enrollment period has ended".to_string(),
             format!("/subjects/electives/trade-offers/{trade_offer_id}"),


### PR DESCRIPTION
This minor release contains extra features and fixes for the 2/2024 electives.

New Route:
 - Get Previously Enrolled Electives => `GET /v1/subjects/electives/previously-enrolled`

Enrollment period checking (`GET /v1/subjects/electives/in-enrollment-period`) now requires a student auth token. It can now check enrolment periods per grade, and a new column has been added to the `elective_subject_enrollment_periods` table.

Resolves BACK-98 and BACK-99.