### PR TITLE
[0.9.0] Organization Authorizer

### DIFF
--- a/mysk-data-api/src/routes/auth/google_oauth_login.rs
+++ b/mysk-data-api/src/routes/auth/google_oauth_login.rs
@@ -92,9 +92,13 @@ pub async fn google_oauth_handler(
     let claims = TokenClaims {
         sub: user.id,
         mta: match user.meta {
-            Some(UserMeta::Student { student_id: id } | UserMeta::Teacher { teacher_id: id }) => {
-                Some(id)
-            }
+            Some(
+                UserMeta::Student { student_id: id }
+                | UserMeta::Teacher { teacher_id: id }
+                | UserMeta::Organization {
+                    organization_id: id,
+                },
+            ) => Some(id),
             _ => None,
         },
         exp,

--- a/mysk-data-api/src/routes/v1/students/modify_student.rs
+++ b/mysk-data-api/src/routes/v1/students/modify_student.rs
@@ -64,6 +64,14 @@ pub async fn modify_student(
     let db_student = DbStudent::get_by_id(&mut conn, student_id).await?;
     let person_id = db_student.person_id;
 
+    // Only the kornor organization can update the club_quota
+    if update_data.club_quota.is_some() && !(authorizer.is_kornor(&mut conn).await?) {
+        return Err(Error::InvalidPermission(
+            "Insufficient permissions to perform this action".to_string(),
+            format!("students/{student_id}"),
+        ));
+    }
+
     authorizer
         .authorize_student(&db_student, &mut conn, ActionType::Update)
         .await?;
@@ -111,7 +119,7 @@ pub async fn modify_student(
 
         person_transaction.commit().await?;
     }
-    
+
     // NOTE: Club-related updates
     if let Some(quota) = update_data.club_quota {
         let current_year = get_current_academic_year(None);
@@ -119,7 +127,7 @@ pub async fn modify_student(
             r#"
             INSERT INTO student_club_quotas (student_id, year, max_clubs)
             VALUES ($1, $2, $3)
-            ON CONFLICT (student_id, year) 
+            ON CONFLICT (student_id, year)
             DO UPDATE SET max_clubs = EXCLUDED.max_clubs
             "#,
             student_id,

--- a/mysk-lib/src/models/user/mod.rs
+++ b/mysk-lib/src/models/user/mod.rs
@@ -14,6 +14,7 @@ pub mod db;
 pub enum UserMeta {
     Student { student_id: Uuid },
     Teacher { teacher_id: Uuid },
+    Organization { organization_id: Uuid },
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -41,7 +42,7 @@ impl User {
                     "\
                     SELECT s.id \
                     FROM students AS s JOIN users AS u ON u.id = s.user_id \
-                    WHERE u.id = $1\
+                    WHERE u.id = $1 AND u.role = 'student'::user_role
                     ",
                     user.id,
                 )
@@ -56,7 +57,22 @@ impl User {
                     "\
                     SELECT t.id \
                     FROM teachers AS t JOIN users AS u ON u.id = t.user_id \
-                    WHERE u.id = $1\
+                    WHERE u.id = $1 AND u.role = 'teacher'::user_role
+                    ",
+                    user.id,
+                )
+                .fetch_one(conn)
+                .await?,
+            }),
+            UserRole::Organization if meta.is_some() => Some(UserMeta::Organization {
+                organization_id: meta.unwrap(),
+            }),
+            UserRole::Organization => Some(UserMeta::Organization {
+                organization_id: query_scalar!(
+                    "\
+                    SELECT o.id \
+                    FROM organizations AS o JOIN users AS u ON u.id = o.user_id \
+                    WHERE u.id = $1 AND u.role = 'organization'::user_role
                     ",
                     user.id,
                 )

--- a/mysk-lib/src/permissions/authorizer.rs
+++ b/mysk-lib/src/permissions/authorizer.rs
@@ -19,7 +19,7 @@ use crate::{
         teacher::db::DbTeacher,
         user::{User, UserMeta},
     },
-    permissions::roles::{AdminRole, ManagementRole, StudentRole, TeacherRole},
+    permissions::roles::{AdminRole, ManagementRole, OrganizationRole, StudentRole, TeacherRole},
     prelude::*,
 };
 use futures::future;
@@ -190,6 +190,7 @@ pub enum Authorizer {
     Management(ManagementRole),
     Student(StudentRole),
     Teacher(TeacherRole),
+    Organization(OrganizationRole),
 }
 
 impl Authorizer {
@@ -206,6 +207,11 @@ impl Authorizer {
                 meta: Some(UserMeta::Teacher { teacher_id }),
                 ..
             } => Self::Teacher(TeacherRole::new(*teacher_id, user.id, source)),
+            User {
+                role: UserRole::Organization,
+                meta: Some(UserMeta::Organization { organization_id }),
+                ..
+            } => Self::Organization(OrganizationRole::new(*organization_id, user.id, source)),
             _ => unimplemented!(),
         }
     }
@@ -223,6 +229,7 @@ impl Authorizable for Authorizer {
             Self::Management(a) => a.authorize_classroom(classroom, conn, action).await,
             Self::Student(a) => a.authorize_classroom(classroom, conn, action).await,
             Self::Teacher(a) => a.authorize_classroom(classroom, conn, action).await,
+            Self::Organization(a) => a.authorize_classroom(classroom, conn, action).await,
         }
     }
 
@@ -237,6 +244,7 @@ impl Authorizable for Authorizer {
             Self::Management(a) => a.authorize_contact(contact, conn, action).await,
             Self::Student(a) => a.authorize_contact(contact, conn, action).await,
             Self::Teacher(a) => a.authorize_contact(contact, conn, action).await,
+            Self::Organization(a) => a.authorize_contact(contact, conn, action).await,
         }
     }
 
@@ -251,6 +259,7 @@ impl Authorizable for Authorizer {
             Self::Management(a) => a.authorize_student(student, conn, action).await,
             Self::Student(a) => a.authorize_student(student, conn, action).await,
             Self::Teacher(a) => a.authorize_student(student, conn, action).await,
+            Self::Organization(a) => a.authorize_student(student, conn, action).await,
         }
     }
 
@@ -265,6 +274,7 @@ impl Authorizable for Authorizer {
             Self::Management(a) => a.authorize_subject(subject, conn, action).await,
             Self::Student(a) => a.authorize_subject(subject, conn, action).await,
             Self::Teacher(a) => a.authorize_subject(subject, conn, action).await,
+            Self::Organization(a) => a.authorize_subject(subject, conn, action).await,
         }
     }
 
@@ -279,6 +289,7 @@ impl Authorizable for Authorizer {
             Self::Management(a) => a.authorize_teacher(teacher, conn, action).await,
             Self::Student(a) => a.authorize_teacher(teacher, conn, action).await,
             Self::Teacher(a) => a.authorize_teacher(teacher, conn, action).await,
+            Self::Organization(a) => a.authorize_teacher(teacher, conn, action).await,
         }
     }
 }

--- a/mysk-lib/src/permissions/authorizer.rs
+++ b/mysk-lib/src/permissions/authorizer.rs
@@ -215,6 +215,14 @@ impl Authorizer {
             _ => unimplemented!(),
         }
     }
+
+    pub async fn is_kornor(&self, conn: &mut PgConnection) -> Result<bool> {
+        match self {
+            Authorizer::Admin(_) => Ok(true), // admins have all permissions
+            Authorizer::Organization(org) => org.is_kornor(conn).await,
+            _ => Ok(false),
+        }
+    }
 }
 
 impl Authorizable for Authorizer {

--- a/mysk-lib/src/permissions/roles/mod.rs
+++ b/mysk-lib/src/permissions/roles/mod.rs
@@ -1,9 +1,11 @@
 mod admin;
 mod management;
+mod organization;
 mod student;
 mod teacher;
 
 pub use admin::AdminRole;
 pub use management::ManagementRole;
+pub use organization::OrganizationRole;
 pub use student::StudentRole;
 pub use teacher::TeacherRole;

--- a/mysk-lib/src/permissions/roles/organization.rs
+++ b/mysk-lib/src/permissions/roles/organization.rs
@@ -1,0 +1,100 @@
+use crate::{
+    models::{
+        classroom::db::DbClassroom, contact::db::DbContact, student::db::DbStudent,
+        subject::db::DbSubject, teacher::db::DbTeacher,
+    },
+    permissions::{ActionType, Authorizable, authorize_read_only},
+    prelude::*,
+};
+use sqlx::{PgConnection, query};
+use uuid::Uuid;
+
+const KORNOR_EMAIL: &str = "kornor@sk.ac.th";
+
+#[derive(Clone, Debug)]
+pub struct OrganizationRole {
+    #[allow(dead_code)]
+    id: Uuid,
+    user_id: Uuid,
+    source: String,
+}
+
+impl Authorizable for OrganizationRole {
+    async fn authorize_classroom(
+        &self,
+        _: &DbClassroom,
+        _: &mut PgConnection,
+        action: ActionType,
+    ) -> Result<()> {
+        authorize_read_only(action, &self.source)
+    }
+
+    async fn authorize_contact(
+        &self,
+        _: &DbContact,
+        _: &mut PgConnection,
+        action: ActionType,
+    ) -> Result<()> {
+        authorize_read_only(action, &self.source)
+    }
+
+    async fn authorize_student(
+        &self,
+        _: &DbStudent,
+        conn: &mut PgConnection,
+        action: ActionType,
+    ) -> Result<()> {
+        // The Kornor organization is permitted to update the `club_quota` field of a student,
+        // this must be enforced at the service layer since the `authorize_student` method is called
+        // for all student-related actions.
+        if matches!(action, ActionType::Update) && self.is_kornor(&mut *conn).await? {
+            return Ok(());
+        }
+
+        authorize_read_only(action, &self.source)
+    }
+
+    async fn authorize_subject(
+        &self,
+        _: &DbSubject,
+        _: &mut PgConnection,
+        action: ActionType,
+    ) -> Result<()> {
+        authorize_read_only(action, &self.source)
+    }
+
+    async fn authorize_teacher(
+        &self,
+        _: &DbTeacher,
+        _: &mut PgConnection,
+        action: ActionType,
+    ) -> Result<()> {
+        authorize_read_only(action, &self.source)
+    }
+}
+
+impl OrganizationRole {
+    pub fn new(id: Uuid, user_id: Uuid, source: String) -> Self {
+        Self {
+            id,
+            user_id,
+            source,
+        }
+    }
+
+    pub async fn is_kornor(&self, conn: &mut PgConnection) -> Result<bool> {
+        Ok(query!(
+            "SELECT EXISTS( \
+                SELECT 1 FROM users \
+                WHERE id = $1 AND email = $2
+                AND role = 'organization'::user_role
+            ) AS exists",
+            self.user_id,
+            KORNOR_EMAIL
+        )
+        .fetch_one(conn)
+        .await?
+        .exists
+        .unwrap_or(false))
+    }
+}


### PR DESCRIPTION
## Changelog
- [x] added an `OrganizationRole` for organizations associated to users
    - general read permissions
- [x] permitted `club_quota` modification only by the _Kornor Organization_ 

## To-do
- [x] `authorize_contact` creation by `ActionType::Create` for organizatons
(why is there a [warning](https://github.com/suankularb-wittayalai-school/mysk-api/blob/58bade108bf56e32a5089f563ab9d168bca16d76/mysk-lib/src/permissions/roles/student.rs#L39-L41) 💀)

Resolves BACK-171